### PR TITLE
Fix Windows compatibility in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         fetch-depth: 0  # Needed for setuptools_scm
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
@@ -95,7 +95,8 @@ jobs:
 
     - name: List build artifacts
       run: |
-        ls -la dist/
+        python -c "import os; print('\\n'.join(f'{f}' for f in os.listdir('dist')))"
+        python -c "import os; [print(f'{f}: {os.path.getsize(os.path.join(\"dist\", f))} bytes') for f in os.listdir('dist')]"
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
@@ -114,7 +115,7 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -126,7 +127,7 @@ jobs:
 
     - name: Test wheel installation
       run: |
-        ls -la dist/
+        python -c "import os; print('Available files:'); [print(f'  {f}') for f in os.listdir('dist')]"
         pip install dist/adri-*.whl
 
     - name: Test CLI functionality


### PR DESCRIPTION
🛠️ **Windows PowerShell Compatibility Fixes for Release Workflow**

## �� **Issue Identified**
Release workflow failing on Windows due to Unix commands:
- ❌ `ls -la dist/` doesn't work in Windows PowerShell 
- ❌ `ls` command not available, caused `PermissionError`

## ✅ **Solution Applied**

### **Cross-Platform File Listing**
**Before (Unix-only):**
```bash
ls -la dist/
```

**After (Cross-platform):**
```python
python -c "import os; print('\\n'.join(f'{f}' for f in os.listdir('dist')))"
python -c "import os; [print(f'{f}: {os.path.getsize(os.path.join(\"dist\", f))} bytes') for f in os.listdir('dist')]"
```

### **GitHub Actions Updates**
- ✅ Updated actions/setup-python@v4 → @v5 for consistency with CI workflow
- ✅ Ensures reliable Python setup across all platforms

## 🚀 **Benefits**
- ✅ **Universal compatibility**: Works on Windows PowerShell, macOS/Linux bash
- ✅ **Consistent tooling**: Matches CI workflow versions  
- ✅ **Release reliability**: Cross-platform release workflow

## 📋 **Files Modified**
- `.github/workflows/release.yml`: Cross-platform command compatibility

Ready to merge and proceed with v4.0.1 release! 🎉