### PR TITLE
Fix Jekyll Pages deployment environment configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,6 +54,9 @@ jobs:
 
   # Deployment job
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
🛠️ **Jekyll Pages Deployment Fix**

## 🎯 **Issue Identified**
Jekyll Pages deployment failing with error:
> Missing environment. Ensure your workflow's deployment job has an environment

## ✅ **Solution Applied**

### **Environment Configuration Added**


### **Root Cause**
-  requires explicit environment configuration
- GitHub Pages deployment needs  environment declared
- Missing environment caused deployment API to reject requests

## 🔍 **Validated with ACT**
- ✅ Jekyll/Ruby components work correctly
- ✅ Bundle installation successful
- ✅ ACT confirmed the environment requirement issue

## 📋 **Files Modified**
- : Added environment configuration to deploy job

Ready to merge and proceed with v4.0.1 release! 🚀