### PR TITLE
docs: Day‑0 UX unification — Core Concepts, quickstart UX, consistent examples, MCP/A2A context

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,48 +2,75 @@
 
 **Prevent AI agent failures with one decorator**
 
-## 30-Second Setup
+## 5-Minute Quickstart
 
 ```bash
 pip install adri
+
+# Bootstrap project folders and sample data
+adri setup --guide
+
+# Generate a standard from your "good" dataset
+adri generate-standard examples/data/invoice_data.csv \
+  --output examples/standards/invoice_data_ADRI_standard.yaml
+
+# Validate a new dataset against the generated standard
+adri assess examples/data/test_invoice_data.csv \
+  --standard examples/standards/invoice_data_ADRI_standard.yaml
 ```
+
+What you should see
+
+- Allowed ✅ when data complies with the generated standard
+- Blocked ❌ with a summary of failed checks when the test data violates the standard
 
 ```python
 from adri import adri_protected
 
-@adri_protected(standard="customer_data")
-def your_agent_function(data):
+@adri_protected(standard="invoice_data_standard", data_param="invoice_rows")
+def your_agent_function(invoice_rows):
     # Your existing code - now protected!
     return result
 ```
 
-**ADRI automatically creates standards from your data patterns and protects your agents from bad data.**
+**ADRI automatically creates standards from your data patterns and blocks bad data before it reaches your agents.**
 
 ## Key Features
 
 - **🛡️ One-Decorator Protection** - Add `@adri_protected` to any function
 - **🤖 Framework Agnostic** - Works with LangChain, CrewAI, AutoGen, LlamaIndex, etc.
-- **🚀 Zero Configuration** - Smart defaults, customize when needed
+- **🚀 Smart Defaults** - Zero-config start with optional fine-grained control
 - **📊 5-Dimension Validation** - Completeness, validity, consistency, plausibility, freshness
 - **📋 Detailed Reporting** - JSON logs and actionable error messages
-- **⚡ Enterprise Ready** - Production-tested with optional enterprise features
+- **⚡ Enterprise Ready** - Local-first with a path to managed Verodat supply
 
 ## Quick Example
 
 ```bash
-# Test data quality
-adri assess customer_data.csv
+# Generate a data standard once
+adri generate-standard data/customers_clean.csv \
+  --output ADRI/dev/standards/customer_data_standard.yaml
 
-# Protect any agent function
-@adri_protected(standard="customer_data")
-def process_customers(data):
-    return ai_analysis(data)  # Only runs on quality data
+# Use the same standard to guard new inputs
+adri assess data/customers_latest.csv \
+  --standard ADRI/dev/standards/customer_data_standard.yaml
+```
+
+```python
+from adri import adri_protected
+
+@adri_protected(standard="customer_data_standard", data_param="invoice_rows")
+def process_customers(invoice_rows):
+    return ai_analysis(invoice_rows)  # Only runs on quality data
 ```
 
 ## Documentation
 
-📖 **[FAQ](docs/faq.md)** - Complete guide covering everything you need to know
-🏗️ **[Architecture](ARCHITECTURE.md)** - How ADRI works
+📖 **[Getting Started](docs/docs/users/getting-started.md)** - Installation and first success
+❓ **[FAQ](docs/docs/users/faq.md)** - Answers for agent engineers and data teams
+🧠 **[Framework Playbooks](docs/docs/users/frameworks.md)** - Copy/paste fixes for LangChain, CrewAI, LlamaIndex, and more
+🧭 **[Adoption Journey](docs/docs/users/adoption-journey.md)** - When to move from local logging to Verodat MCP
+🏗️ **[Architecture](ARCHITECTURE.md)** - How ADRI is built
 📋 **[Examples](examples/)** - Ready-to-run use cases and standards
 🤝 **[Contributing](CONTRIBUTING.md)** - Join the community
 
@@ -56,7 +83,7 @@ ADRI works seamlessly with all major AI frameworks:
 - **LlamaIndex** - Guard query engines
 - **Any Python Function** - Universal protection
 
-See [docs/frameworks.md](docs/frameworks.md) for copy-paste examples.
+See [docs/docs/users/frameworks.md](docs/docs/users/frameworks.md) for copy-paste playbooks.
 
 ## Support
 
@@ -65,11 +92,9 @@ See [docs/frameworks.md](docs/frameworks.md) for copy-paste examples.
 
 ---
 
-## ADRI Enterprise
+## ADRI Adoption Path
 
-The open-source edition of ADRI is complete and free for all users.
-
-For organizations that need advanced compliance logging, managed data supply, and enterprise support, see [ADRI Enterprise](https://verodat.com/adri-enterprise/).
+See the Adoption Journey for next steps: [docs/docs/users/adoption-journey.md](docs/docs/users/adoption-journey.md)
 
 ---
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,55 +5,69 @@ slug: /
 
 # ADRI Documentation
 
-**Agent Data Reliability Intelligence - Stop AI agents from breaking on bad data**
+**Agent Data Reliability Intelligence – Stop AI agents from breaking on bad data**
 
-ADRI is an open-source data quality validation framework designed specifically for AI agents. One decorator protects your agent functions from unreliable data across all major frameworks.
+ADRI is an open-source data quality validation framework built for AI agents. Generate a standard from good data once, wrap your functions with `@adri_protected`, and block dirty payloads before they crash your agents.
+
+## ADRI in your stack
+
+ADRI is a data quality gate for agent workflows. It complements related standards you may already use:
+
+- ADRI: Validate inputs and enforce a quality contract before tools/actions run (fail-fast, warn, or continue).
+- MCP: Agent-to-tool connectivity (standard way to connect agents to tools, APIs, and resources). See https://modelcontextprotocol.io/
+- A2A: Agent-to-agent interoperability (standard messaging between agents across frameworks/vendors). See https://a2a-protocol.org/latest/
+
+Use ADRI with or without MCP/A2A — the goal is to stop bad data from breaking agents right at the boundary.
+
 
 ## Choose Your Path
 
 ### 🚀 **Put ADRI to Work**
-*Package consumer documentation - Get started with ADRI*
+*Package consumer documentation – ship reliable agents fast*
 
 ```bash
 pip install adri
+adri setup --guide
+adri generate-standard examples/data/invoice_data.csv \
+  --output examples/standards/invoice_data_ADRI_standard.yaml
+adri assess examples/data/test_invoice_data.csv \
+  --standard examples/standards/invoice_data_ADRI_standard.yaml
 ```
 
 ```python
 from adri import adri_protected
 
-@adri_protected(standard="customer_data")
-def your_agent_function(data):
-    # Your existing code - now protected!
-    return result
+@adri_protected(standard="invoice_data_standard", data_param="invoice_rows")
+def your_agent_function(invoice_rows):
+    return agent_pipeline(invoice_rows)
 ```
 
 **📚 User Documentation:**
-- **[Getting Started](users/getting-started)** - Installation and first steps
-- **[FAQ](users/faq)** - Complete guide covering everything you need
-- **[Framework Examples](users/frameworks)** - LangChain, CrewAI, AutoGen integration
-- **[API Reference](users/API_REFERENCE)** - Complete technical reference
-- **[Why Open Source](users/WHY_OPEN_SOURCE)** - Our open source philosophy
+- **[Getting Started](users/getting-started)** – Installation, walkthrough, and first success
+- **[FAQ](users/faq)** – Answers for agent engineers, data teams, and compliance
+- **[Framework Playbooks](users/frameworks)** – LangChain, CrewAI, LlamaIndex, LangGraph, Semantic Kernel
+- **[Adoption Journey](users/adoption-journey)** – When to switch on Verodat-managed data supply
+- **[API Reference](users/API_REFERENCE)** – Complete decorator, CLI, and configuration details
+- **[Why Open Source](users/WHY_OPEN_SOURCE)** – Strategy and licensing
 
 ### 🛠️ **Contribute to ADRI Community**
-*Developer documentation - Help improve ADRI*
+*Developer documentation – improve ADRI itself*
 
 **🔧 Contributor Documentation:**
-- **[Development Workflow](contributors/development-workflow)** - Local testing and CI setup
-- **[Framework Extension Pattern](contributors/framework-extension-pattern)** - Adding new framework support
-- **[Code Style Guide](https://github.com/adri-standard/adri/blob/main/CONTRIBUTING.md)** - Contribution guidelines
-- **[GitHub Repository](https://github.com/adri-standard/adri)** - Source code and issues
+- **[Development Workflow](contributors/development-workflow)** – Local testing and CI setup
+- **[Framework Extension Pattern](contributors/framework-extension-pattern)** – Adding new framework support
+- **[Code Style Guide](https://github.com/adri-standard/adri/blob/main/CONTRIBUTING.md)** – Contribution guidelines
+- **[GitHub Repository](https://github.com/adri-standard/adri)** – Source code and issues
 
 ## Key Features
 
-- **🛡️ One-Decorator Protection** - Add `@adri_protected` to any function
-- **🤖 Framework Agnostic** - Works with LangChain, CrewAI, AutoGen, LlamaIndex, etc.
-- **🚀 Zero Configuration** - Smart defaults, customize when needed
-- **📊 5-Dimension Validation** - Completeness, validity, consistency, plausibility, freshness
-- **📋 Flexible Modes** - Fail-fast, selective blocking, or warn-only
-- **⚡ Enterprise Ready** - Production-tested with optional enterprise features
+- **🛡️ One-Decorator Protection** – Add `@adri_protected` to any function
+- **🤖 Framework Agnostic** – Works with LangChain, CrewAI, AutoGen, LlamaIndex, etc.
+- **🚀 Smart Defaults** – Zero-config start with optional tuning
+- **📊 Five Dimensions** – Validity, completeness, consistency, plausibility, freshness
+- **📋 Flexible Modes** – Fail-fast, warn, or continue for selective flows
+- **⚡ Enterprise Ready** – Local-first with a clear path to Verodat MCP
 
 ---
 
-**Ready to start?** Choose your path above - whether you want to **use ADRI** or **contribute to ADRI**.
-
-*Documentation updated: Testing artifact fix deployment.*
+**Ready to start?** Hit the getting started guide, then follow the adoption journey when you need shared compliance logging and managed data supply.

--- a/docs/docs/users/API_REFERENCE.md
+++ b/docs/docs/users/API_REFERENCE.md
@@ -4,710 +4,237 @@ sidebar_position: 5
 
 # ADRI API Reference
 
-**Stop AI Agents Breaking on Bad Data**
-One line of code. Any framework. Bulletproof agents.
+**Stop AI agents breaking on bad data**
+One decorator. Consistent CLI commands. Predictable logs.
 
 ## Quick Reference
 
 ```python
-# Basic protection (most common)
-@adri_protected(data_param="your_data")
-def your_agent(your_data):
-    return process_data(your_data)
+from adri import adri_protected
 
-# Custom requirements
-@adri_protected(data_param="data", min_score=90)
-def strict_agent(data):
-    return analyze_data(data)
+@adri_protected(
+    standard="invoice_data_standard",
+    data_param="invoice_rows",
+    min_score=85,
+    on_failure="warn",
+)
+def process_invoices(invoice_rows):
+    return pipeline(invoice_rows)
 ```
 
-## Table of Contents
-1. [Essential Decorator](#essential-decorator) ⭐ **Start Here**
-2. [Framework Examples](#framework-examples)
-3. [Configuration](#configuration)
-4. [CLI Commands](#cli-commands)
-5. [Advanced Usage](#advanced-usage)
-6. [Core Classes](#core-classes)
-7. [Utilities](#utilities)
+```bash
+# Generate a standard from a known-good dataset
+adri generate-standard examples/data/invoice_data.csv \
+  --output examples/standards/invoice_data_ADRI_standard.yaml
+
+# Assess an inbound dataset against that standard
+adri assess examples/data/test_invoice_data.csv \
+  --standard examples/standards/invoice_data_ADRI_standard.yaml
+```
+
+> Standard reference: The decorator uses a logical name (omit `.yaml`), while the CLI expects a filesystem path. See [Core Concepts](core-concepts.md) for details and the five dimensions.
 
 ---
 
-## Essential Decorator
+## Decorator API
 
-### `@adri_protected` ⭐
+### `adri.adri_protected`
 
-The one decorator you need to protect any AI agent.
+Protect any callable with pre-execution data quality checks.
 
 ```python
-from adri.decorators.guard import adri_protected
-
-@adri_protected(
-    data_param: str,           # Which parameter contains your data
-    min_score: float = 80.0,   # Quality threshold (0-100)
-    on_failure: str = "raise", # What to do if data is bad
-    verbose: bool = False      # Show protection messages
+adri_protected(
+    standard: str,
+    data_param: str = "data",
+    min_score: float | None = None,
+    dimensions: dict[str, float] | None = None,
+    on_failure: str | None = None,  # "raise", "warn", or "continue"
+    auto_generate: bool = True,
+    cache_assessments: bool | None = None,
+    verbose: bool | None = None,
 )
 ```
-
-#### Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `standard` | `str` | Required | Name of the YAML standard to use for validation |
-| `data_arg` | `str` | Auto-detect | Name of the argument containing data to validate |
-| `min_score` | `float` | 75.0 | Minimum quality score required (0-100) |
-| `failure_mode` | `str` | "raise" | Action on failure: "raise", "warn", or "log" |
-| `cache_duration` | `int` | 300 | Cache duration in seconds |
-| `audit_enabled` | `bool` | False | Enable audit logging for this function |
+| `standard` | `str` | required | Name of the YAML standard to load (omit `.yaml`). Must exist in `ADRI/**/standards` or be auto-generated. |
+| `data_param` | `str` | `"data"` | Name of the function argument that contains the dataset. Required when your argument isn’t literally called `data`. |
+| `min_score` | `float` | config default | Minimum overall score (0–100). When omitted ADRI reads `default_min_score` from configuration. |
+| `dimensions` | `dict[str, float]` | `None` | Optional per-dimension minimums (each value 0–20). Example: `{ "validity": 18, "freshness": 16 }`. |
+| `on_failure` | `str` | config default | Values: `"raise"`, `"warn"`, or `"continue"`. Controls how ADRI responds when data fails validation. |
+| `auto_generate` | `bool` | `True` | Allow ADRI to create a standard automatically if the referenced file does not exist. |
+| `cache_assessments` | `bool` | config default | Toggle short-term caching of assessment results for identical inputs. |
+| `verbose` | `bool` | config default | Emit detailed protection logs for debugging. |
 
-#### Example
+Returns the wrapped function. Raises `ProtectionError` when `on_failure="raise"` and the data does not pass requirements.
+
+#### Usage Patterns
 
 ```python
-import pandas as pd
-from adri.decorators import adri_protected
+# Strict production workflow
+@adri_protected(standard="financial_data_standard", data_param="ledger", min_score=95)
 
+def reconcile(ledger):
+    ...
+
+# Warn-only for a pilot rollout
 @adri_protected(
-    standard="customer_data_standard",
-    min_score=80.0,
-    failure_mode="raise",
-    audit_enabled=True
+    standard="support_tickets_standard",
+    data_param="tickets",
+    on_failure="warn",
+    verbose=True,
 )
-def process_customer_data(df: pd.DataFrame) -> pd.DataFrame:
-    # Your data processing logic
-    return df
+def summarize_tickets(tickets):
+    ...
 
-# Usage
-df = pd.DataFrame({
-    'customer_id': [1, 2, 3],
-    'email': ['user1@example.com', 'user2@example.com', 'user3@example.com'],
-    'age': [25, 30, 35]
-})
-
-result = process_customer_data(df)  # Validates before processing
-```
-
----
-
-## Core Classes
-
-### AssessmentEngine
-
-Performs data quality assessments against ADRI standards.
-
-```python
-from adri.core.assessor import AssessmentEngine
-```
-
-#### Methods
-
-##### `__init__(config: Optional[Dict[str, Any]] = None)`
-
-Initialize the assessment engine with optional configuration.
-
-##### `assess(data: pd.DataFrame, standard: Dict[str, Any]) -> AssessmentResult`
-
-Perform a comprehensive data quality assessment.
-
-**Parameters:**
-- `data`: DataFrame to assess
-- `standard`: ADRI standard dictionary
-
-**Returns:** `AssessmentResult` object with scores and details
-
-**Example:**
-```python
-from adri.core.assessor import AssessmentEngine
-from adri.standards.loader import StandardsLoader
-
-engine = AssessmentEngine()
-loader = StandardsLoader()
-
-standard = loader.load_standard("customer_data_standard")
-result = engine.assess(df, standard)
-
-print(f"Overall Score: {result.overall_score}")
-print(f"Passed: {result.passed}")
-```
-
-### AssessmentResult
-
-Result object from data quality assessment.
-
-```python
-from adri.core.assessor import AssessmentResult
-```
-
-#### Attributes
-
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `overall_score` | `float` | Overall quality score (0-100) |
-| `dimension_scores` | `Dict[str, DimensionScore]` | Scores for each dimension |
-| `passed` | `bool` | Whether assessment passed minimum threshold |
-| `timestamp` | `datetime` | When assessment was performed |
-| `standard_id` | `str` | ID of standard used |
-| `metadata` | `Dict[str, Any]` | Additional assessment metadata |
-
-#### Methods
-
-##### `to_dict() -> Dict[str, Any]`
-Convert result to dictionary format.
-
-##### `to_json() -> str`
-Convert result to JSON string.
-
-### DataProtectionEngine
-
-Enforces data quality gates on function calls.
-
-```python
-from adri.core.protection import DataProtectionEngine
-```
-
-#### Methods
-
-##### `__init__(config: Optional[Dict[str, Any]] = None)`
-Initialize the protection engine.
-
-##### `protect_function_call(func: Callable, *args, **kwargs) -> Any`
-Protect a function call with data quality validation.
-
-**Parameters:**
-- `func`: Function to protect
-- `*args`: Positional arguments for the function
-- `**kwargs`: Keyword arguments for the function
-
-**Returns:** Function result if validation passes
-
-**Example:**
-```python
-from adri.core.protection import DataProtectionEngine
-
-engine = DataProtectionEngine({
-    "min_score": 75.0,
-    "failure_mode": "raise"
-})
-
-def process_data(df):
-    return df.describe()
-
-result = engine.protect_function_call(
-    process_data,
-    df,
-    standard="test_standard"
+# Apply per-dimension minimums
+@adri_protected(
+    standard="customer_profile_standard",
+    data_param="rows",
+    dimensions={"validity": 18, "freshness": 15},
 )
+def update_profiles(rows):
+    ...
 ```
-
----
-
-## Standards Management
-
-### StandardsLoader
-
-Manages loading and caching of YAML standards.
-
-```python
-from adri.standards.loader import StandardsLoader
-```
-
-#### Methods
-
-##### `__init__()`
-Initialize the standards loader.
-
-##### `load_standard(standard_name: str) -> Dict[str, Any]`
-Load a standard by name.
-
-**Parameters:**
-- `standard_name`: Name of the standard (without .yaml extension)
-
-**Returns:** Dictionary containing the standard definition
-
-**Raises:** `StandardNotFoundError` if standard doesn't exist
-
-##### `list_available_standards() -> List[str]`
-Get list of all available standards.
-
-**Returns:** List of standard names
-
-##### `get_standard_metadata(standard_name: str) -> Dict[str, Any]`
-Get metadata for a standard without loading full content.
-
-**Returns:** Dictionary with name, version, description, file_path
-
-##### `standard_exists(standard_name: str) -> bool`
-Check if a standard exists.
-
-##### `clear_cache()`
-Clear the internal cache of loaded standards.
-
-#### Example
-
-```python
-from adri.standards.loader import StandardsLoader
-
-loader = StandardsLoader()
-
-# List available standards
-standards = loader.list_available_standards()
-print(f"Available standards: {standards}")
-
-# Load a specific standard
-standard = loader.load_standard("customer_data_standard")
-print(f"Standard version: {standard['standards']['version']}")
-
-# Get metadata only
-metadata = loader.get_standard_metadata("customer_data_standard")
-print(f"Description: {metadata['description']}")
-```
-
-### Convenience Functions
-
-```python
-from adri.standards.loader import load_bundled_standard, list_bundled_standards
-
-# Quick access to standards
-standard = load_bundled_standard("test_standard")
-all_standards = list_bundled_standards()
-```
-
----
-
-## Configuration
-
-### ConfigManager
-
-Manages configuration with hierarchy: defaults → file → environment → runtime.
-
-```python
-from adri.config.manager import ConfigManager
-```
-
-#### Methods
-
-##### `__init__(config_path: Optional[str] = None)`
-Initialize with optional config file path.
-
-##### `get_config(section: Optional[str] = None) -> Dict[str, Any]`
-Get configuration for a section or all config.
-
-##### `get_protection_config() -> Dict[str, Any]`
-Get data protection configuration.
-
-##### `get_audit_config() -> Dict[str, Any]`
-Get audit logging configuration.
-
-##### `update_config(updates: Dict[str, Any], section: Optional[str] = None)`
-Update configuration at runtime.
-
-#### Configuration Structure
-
-```yaml
-adri:
-  protection:
-    min_score: 75.0              # Minimum quality score (0-100)
-    failure_mode: "raise"        # raise | warn | log
-    cache_duration: 300          # Seconds to cache results
-    cache_enabled: true
-
-  audit:
-    enabled: false               # Enable audit logging
-    log_location: "./logs/adri_audit.jsonl"
-    log_level: "INFO"           # INFO | DEBUG | ERROR
-    include_data_samples: false  # Include data in logs
-    max_log_size_mb: 100        # Rotate after size
-    batch_mode: false           # Batch audit records
-    batch_size: 100
-
-  standards:
-    path: null                  # Custom standards path
-    cache_enabled: true         # Cache loaded standards
-
-  verodat:                     # Optional Verodat integration
-    enabled: false
-    api_url: "https://api.verodat.com"
-    api_key: null
-    workspace_id: null
-    account_id: null
-```
-
----
-
-## Audit Logging
-
-### AuditLogger
-
-Records comprehensive audit trail for assessments.
-
-```python
-from adri.core.audit_logger import AuditLogger
-```
-
-#### Methods
-
-##### `__init__(config: Optional[Dict[str, Any]] = None)`
-Initialize audit logger with configuration.
-
-##### `log_assessment(...) -> Optional[AuditRecord]`
-Log an assessment to audit trail.
-
-**Parameters:**
-- `assessment_result`: Assessment result object
-- `execution_context`: Context about function execution
-- `data_info`: Information about assessed data
-- `performance_metrics`: Performance metrics
-- `failed_checks`: List of failed validation checks
-
-**Returns:** `AuditRecord` if logging enabled, None otherwise
-
-### AuditRecord
-
-Structured audit record for assessments.
-
-```python
-from adri.core.audit_logger import AuditRecord
-```
-
-#### Methods
-
-##### `to_dict() -> Dict[str, Any]`
-Convert to dictionary format.
-
-##### `to_json() -> str`
-Convert to JSON string.
-
-##### `to_verodat_format() -> Dict[str, Any]`
-Convert to Verodat-compatible format.
-
-### AuditLoggerCSV
-
-CSV-based audit logger for file output.
-
-```python
-from adri.core.audit_logger_csv import AuditLoggerCSV
-```
-
-#### Example
-
-```python
-from adri.core.audit_logger_csv import AuditLoggerCSV
-
-logger = AuditLoggerCSV({
-    "enabled": True,
-    "output_path": "./audit_logs",
-    "rotation": "daily"
-})
-
-# Logger automatically used by @adri_protected when configured
-```
-
----
-
-## Utilities
-
-### Verification Utilities
-
-Verify standalone installation and operation.
-
-```python
-from adri.utils.verification import (
-    verify_standalone_installation,
-    list_bundled_standards,
-    check_system_compatibility,
-    verify_audit_logging,
-    run_full_verification
-)
-```
-
-#### Functions
-
-##### `verify_standalone_installation() -> Tuple[bool, List[str]]`
-Verify standalone installation.
-
-**Returns:** (success: bool, messages: List[str])
-
-##### `list_bundled_standards() -> List[Dict[str, str]]`
-List all bundled standards with metadata.
-
-##### `check_system_compatibility() -> Dict[str, Any]`
-Check system compatibility.
-
-##### `verify_audit_logging(enabled: bool = False) -> Tuple[bool, List[str]]`
-Verify audit logging functionality.
-
-##### `run_full_verification(verbose: bool = True) -> bool`
-Run complete verification suite.
-
-#### Example
-
-```python
-from adri.utils.verification import run_full_verification
-
-# Run full verification
-if run_full_verification(verbose=True):
-    print("✅ All verifications passed")
-else:
-    print("❌ Some verifications failed")
-```
-
-### Component Boundary
-
-Manage boundaries with external systems.
-
-```python
-from adri.core.boundary import (
-    ComponentBoundary,
-    StandaloneMode,
-    get_boundary_manager,
-    validate_standalone_operation
-)
-```
-
-#### StandaloneMode Context Manager
-
-```python
-from adri.core.boundary import StandaloneMode
-
-# Force standalone operation
-with StandaloneMode():
-    # All external integrations disabled
-    result = process_data(df)
-```
-
-#### ComponentBoundary Methods
-
-##### `register_integration(name: str, integration: ExternalIntegration, config: IntegrationConfig) -> bool`
-Register an external integration.
-
-##### `register_data_provider(name: str, provider: DataProvider) -> bool`
-Register a data provider.
-
-##### `register_audit_sink(name: str, sink: AuditSink) -> bool`
-Register an audit sink.
-
-##### `health_check() -> Dict[str, bool]`
-Check health of all integrations.
-
-##### `shutdown_all() -> bool`
-Shutdown all integrations.
 
 ---
 
 ## CLI Commands
 
-### Main Command
+ADRI ships with a streamlined Click-based CLI (`adri`). All commands can be run from any subdirectory inside your project thanks to automatic root detection.
 
-```bash
-adri [OPTIONS] COMMAND [ARGS]...
+| Command | Purpose | Key Options |
+|---------|---------|-------------|
+| `adri setup` | Create ADRI folder structure (`ADRI/dev`, `ADRI/prod`) and optional sample data. | `--guide`, `--force`, `--project-name` |
+| `adri generate-standard <data>` | Profile a dataset and write a YAML standard. | `--output`, `--force`, `--guide` |
+| `adri assess <data> --standard <path>` | Validate data against a standard and emit reports. | `--output`, `--guide` |
+| `adri list-standards` | List available standards in the active environment. | – |
+| `adri show-standard <name>` | Display requirements for a particular standard. | – |
+| `adri validate-standard <path>` | Validate the structure of a YAML standard. | – |
+| `adri show-config` | Print the active configuration (paths, protection defaults, environments). | `--paths-only`, `--environment` |
+| `adri list-assessments` | View recent assessment runs from `ADRI/**/assessments`. | `--recent`, `--verbose` |
+| `adri view-logs` | Tail audit logs when logging is enabled. | – |
+| `adri help-guide` | Re-display the guided tutorial walkthrough. | – |
+
+All commands support relative paths (e.g. `examples/data/test_invoice_data.csv`) because ADRI resolves them against the detected project root. Use `adri show-config --paths-only` to confirm where reports and standards are written.
+
+---
+
+## Standards & Validation Engine
+
+### `adri.standards.parser.StandardsParser`
+
+Loads, validates, and caches YAML standards. Set the environment variable `ADRI_STANDARDS_PATH` to point at the directory that contains your YAML files before instantiating the parser.
+
+```python
+import os
+os.environ['ADRI_STANDARDS_PATH'] = '/path/to/ADRI/dev/standards'
+
+from adri.standards.parser import StandardsParser
+
+parser = StandardsParser()
+standard = parser.parse_standard('customer_data_standard')
+metadata = parser.get_standard_metadata('customer_data_standard')
 ```
 
-### Commands
+### `adri.validator.engine.ValidationEngine`
 
-#### `validate`
-Validate data file against a standard.
+Core engine that scores datasets against rules.
 
-```bash
-adri validate --data data.csv --standard customer_data_standard
+```python
+from adri.validator.engine import ValidationEngine
+
+engine = ValidationEngine()
+result = engine.assess(dataframe, standard_dict)
+print(result.overall_score)
 ```
 
-**Options:**
-- `--data PATH`: Path to data file (CSV/Parquet)
-- `--standard TEXT`: Standard name
-- `--min-score FLOAT`: Minimum score (default: 75.0)
-- `--output PATH`: Output report path
+### `adri.validator.engine.DataQualityAssessor`
 
-#### `list-standards`
-List all available standards.
+High-level helper used by the CLI to combine loading, scoring, and reporting.
 
-```bash
-adri list-standards
+```python
+from adri.validator.engine import DataQualityAssessor
+
+assessor = DataQualityAssessor()
+assessment = assessor.assess(df, "ADRI/dev/standards/customer_data_standard.yaml")
+print(assessment.dimension_scores["validity"].score)
 ```
 
-#### `show-standard`
-Display details of a specific standard.
+All assessment results expose `overall_score`, `dimension_scores`, `passed`, `failed_checks`, and formatting helpers (`to_standard_dict`, `to_json`).
 
-```bash
-adri show-standard customer_data_standard
+---
+
+## Protection Engine Internals
+
+### `adri.guard.modes.DataProtectionEngine`
+
+```python
+from adri.guard.modes import DataProtectionEngine, ProtectionError
+
+engine = DataProtectionEngine()
+try:
+    result = engine.protect_function_call(
+        func=process_data,
+        args=(dataset,),
+        kwargs={},
+        data_param="dataset",
+        function_name="process_data",
+        standard_name="customer_data_standard",
+        min_score=80,
+        on_failure="raise",
+    )
+except ProtectionError as exc:
+    handle_failure(exc)
 ```
 
-#### `verify`
-Verify standalone installation.
+`DataProtectionEngine` chooses the appropriate protection mode (fail-fast, warn-only, or selective) based on configuration or overrides and ensures audit logs are captured when configured.
 
-```bash
-adri verify
+---
+
+## Configuration Loader
+
+### `adri.config.loader.ConfigurationLoader`
+
+```python
+from adri.config.loader import ConfigurationLoader
+
+loader = ConfigurationLoader()
+config_path = loader.find_config_file()
+config = loader.load_config(config_path) if config_path else None
+
+if not config:
+    config = loader.create_default_config(project_name="customer-agents")
+    loader.save_config(config, "ADRI/config.yaml")
+
+active = loader.get_active_config()
+print(active["adri"]["protection"]["default_min_score"])
 ```
 
-#### `config`
-Display current configuration.
+The loader understands the schema documented in [Getting Started](getting-started.md#configure-adri-optional) and merges environment overrides automatically.
 
-```bash
-adri config [--section SECTION]
-```
+---
+
+## Logging
+
+ADRI supports local CSV logging and Verodat Enterprise logging through:
+
+- `adri.logging.local.LocalLogger` – writes CSV audit artifacts under `ADRI/**/audit-logs` and is enabled when local audit logging is turned on in configuration.
+- `adri.logging.enterprise.EnterpriseLogger` – streams structured events to Verodat MCP workspaces once Verodat credentials are configured.
+
+Configure these behaviours in `ADRI/config.yaml` under `adri.audit` and `adri.verodat`. See the [Adoption Journey](adoption-journey.md) for when to enable enterprise logging.
 
 ---
 
 ## Exceptions
 
-### Standard Exceptions
+- `adri.guard.modes.ProtectionError` – Raised when fail-fast protection blocks execution.
+- `adri.standards.exceptions.StandardNotFoundError` – Triggered when the requested standard cannot be located.
+- `adri.standards.exceptions.InvalidStandardError` – Raised when a malformed standard fails validation.
+- `adri.standards.exceptions.StandardsDirectoryNotFoundError` – Raised when `ADRI_STANDARDS_PATH` is missing or incorrect.
 
-```python
-from adri.standards.exceptions import (
-    StandardNotFoundError,
-    InvalidStandardError,
-    StandardsDirectoryNotFoundError
-)
-```
-
-#### StandardNotFoundError
-Raised when a requested standard doesn't exist.
-
-```python
-try:
-    standard = loader.load_standard("nonexistent")
-except StandardNotFoundError as e:
-    print(f"Standard not found: {e}")
-```
-
-#### InvalidStandardError
-Raised when a standard has invalid structure.
-
-#### StandardsDirectoryNotFoundError
-Raised when standards directory is missing.
-
-### Assessment Exceptions
-
-```python
-from adri.core.exceptions import (
-    AssessmentError,
-    DataQualityError,
-    ConfigurationError
-)
-```
-
-#### AssessmentError
-Base exception for assessment failures.
-
-#### DataQualityError
-Raised when data fails quality checks.
-
-```python
-try:
-    result = engine.assess(df, standard)
-except DataQualityError as e:
-    print(f"Quality check failed: {e}")
-```
-
-#### ConfigurationError
-Raised for configuration issues.
+Always catch `ProtectionError` around guarded functions if your workflow needs custom remediation. Use the standards exceptions to surface configuration issues early in CI.
 
 ---
 
-## Advanced Usage
-
-### Custom Standards Path
-
-```python
-import os
-os.environ['ADRI_STANDARDS_PATH'] = '/path/to/custom/standards'
-
-from adri.standards.loader import StandardsLoader
-loader = StandardsLoader()  # Will use custom path
-```
-
-### Programmatic Configuration
-
-```python
-from adri.config.manager import ConfigManager
-
-config = ConfigManager()
-config.update_config({
-    "min_score": 90.0,
-    "failure_mode": "warn"
-}, section="protection")
-```
-
-### Batch Processing
-
-```python
-import pandas as pd
-from adri.decorators import adri_protected
-
-@adri_protected(
-    standard="transaction_data_standard",
-    cache_duration=3600  # Cache for 1 hour
-)
-def process_batch(df: pd.DataFrame) -> pd.DataFrame:
-    return df
-
-# Process multiple batches
-for batch_file in batch_files:
-    df = pd.read_csv(batch_file)
-    result = process_batch(df)
-    save_result(result)
-```
-
-### Custom Audit Sink
-
-```python
-from adri.core.boundary import get_boundary_manager
-
-class CustomAuditSink:
-    def write_record(self, record):
-        # Custom implementation
-        send_to_siem(record)
-        return True
-
-    def flush(self):
-        return True
-
-    def close(self):
-        return True
-
-boundary = get_boundary_manager()
-boundary.register_audit_sink("siem", CustomAuditSink())
-```
-
----
-
-## Environment Variables
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ADRI_STANDARDS_PATH` | Custom standards directory | Bundled standards |
-| `ADRI_CONFIG_PATH` | Configuration file path | `./adri-config.yaml` |
-| `ADRI_ENV` | Environment name | `PRODUCTION` |
-| `ADRI_LOG_LEVEL` | Logging level | `INFO` |
-| `ADRI_AUDIT_ENABLED` | Enable audit logging | `false` |
-| `ADRI_CACHE_ENABLED` | Enable caching | `true` |
-
----
-
-## Performance Tips
-
-1. **Enable Caching**: Use `cache_duration` parameter for repeated validations
-2. **Batch Processing**: Process data in batches for large datasets
-3. **Selective Validation**: Use `data_arg` to validate specific columns
-4. **Async Processing**: Use thread pools for parallel validation
-5. **Memory Management**: Clear cache periodically with `loader.clear_cache()`
-
----
-
-## Migration from v2.x
-
-### Breaking Changes
-- `adri-standards` package no longer required
-- Standards now bundled with validator
-- New audit logging system
-- Component boundary management
-
-### Migration Steps
-
-1. Remove `adri-standards` dependency
-2. Update standard names (add `_standard` suffix)
-3. Update configuration format
-4. Add audit configuration if needed
-5. Test with `adri verify`
-
----
-
-*API Reference for ADRI Validator v3.0.1*
+*API reference for ADRI v3.x. If the code changes, update this document alongside the implementation.*

--- a/docs/docs/users/adoption-journey.md
+++ b/docs/docs/users/adoption-journey.md
@@ -1,0 +1,76 @@
+---
+id: adoption-journey
+sidebar_position: 6
+title: ADRI Adoption Journey
+slug: /users/adoption-journey
+---
+
+# ADRI Adoption Journey
+
+**Take AI agents from local protection to governed enterprise data supply.** This guide connects the open-source toolkit to Verodat MCP so you know exactly when to switch on managed services.
+
+## Overview
+
+| Step | Outcome | ADRI OSS | Verodat MCP / Enterprise | What to show | Revenue Model |
+|------|---------|----------|---------------------------|--------------|---------------|
+| 1 | Define data need | ✅ | – | Run `adri setup --guide` and capture "good" data | OSS – Free |
+| 2 | Block bad data | ✅ | – | `@adri_protected(..., on_failure="raise")` blocks failures | OSS – Free |
+| 3 | Handle error data | ✅ | – | Review JSON reports in `ADRI/dev/assessments` | OSS – Free |
+| 4 | Log for dev (local) | ✅ | – | Enable local audit in config, tail CSV logs | OSS – Free |
+| 5 | Log for prod | ✅ | ✅ | Send audit events to Verodat workspace | Token burn-down (single app) |
+| 6 | Analyse performance & compliance | ✅ | ✅* | Use Claude project connected to Verodat ADRI | Token burn-down |
+| 7 | Publish to datasets | ✅ | ✅* | Publish standards to Verodat datasets | Token burn-down + Dataset licence |
+| 8 | Prove enterprise scope | ✅ | ✅ | Configure agent tools in `tools.verodat.io` | Token burn-down + Dataset licence |
+| 9 | Meet compliance requirements | ✅ | ✅ | Replay logs + controlled data supply | Token burn-down + Dataset licence |
+| 10 | Ship AI solutions | ✅ | ✅ | Share ADRI standards in marketplace | Token burn-down + Dataset licence |
+
+> ✅* indicates the open-source edition makes it possible, but Verodat MCP reduces the effort to near-zero.
+
+## Stage 1 – Local Wins (Steps 1–4)
+
+1. **Create standards quickly** – `adri generate-standard` gives you a YAML contract in minutes. Store it in git with your agent code.
+2. **Block bad inputs immediately** – Use `@adri_protected(standard="...", data_param="...", on_failure="raise")` in production pathways.
+3. **Understand failures** – Inspect the JSON report or call `adri show-standard` to see which rule fired.
+4. **Capture local evidence** – Flip the `adri.protection.verbose_protection` flag or enable local audit logs when you need traceability during development.
+
+👉 Deliverable: reliable agents, developer trust, no platform commitment yet.
+
+## Stage 2 – Shared Visibility (Steps 5–7) {#stage-2}
+
+5. **Stream logs to Verodat** – Configure enterprise logging so assessments land in a governed workspace (`adri.logging.enterprise` with Verodat credentials). Product teams and compliance view the same evidence.
+6. **Analyse trends with Claude projects** – Use Verodat’s MCP integration to benchmark failure patterns, drill into compliance questions, and auto-generate remediation tickets.
+7. **Publish standards as datasets** – Promote validated ADRI standards into Verodat datasets so downstream teams query the same definitions via managed endpoints.
+
+👉 Outcome: single-source-of-truth for standards + logs, lightweight governance, usage-based billing.
+
+## Stage 3 – Enterprise Delivery (Steps 8–10)
+
+8. **Expose agent configuration** – Manage tool access, rate limits, and data supply governance in `tools.verodat.io` so every agent run is compliant by default.
+9. **Prove compliance** – Use replayable logs, deterministic data supply, and Verodat audit views to satisfy ISO/SOC/HIPAA reviews.
+10. **Ship packaged AI solutions** – Publish ADRI-backed standards to the marketplace so partners consume the same high-quality data contracts.
+
+👉 Outcome: production-grade data supply for AI agents with revenue alignment to usage.
+
+## Implementation Checklist
+
+- [ ] Follow the [Getting Started guide](getting-started.md) to complete Steps 1–4.
+- [ ] Enable local audit logging when stakeholders ask for evidence.
+- [ ] Schedule a Verodat MCP onboarding session before promoting to production (Steps 5–7).
+- [ ] Connect enterprise logging and Claude analysis before compliance reviews (Steps 8–9).
+- [ ] Package your standards for marketplace distribution (Step 10).
+
+## How to Talk About the Journey
+
+| Persona | Why it matters | Message |
+|---------|----------------|---------|
+| Agent engineer | Needs confidence that agents won’t crash on bad data | “Guard your function with one decorator, see the pass/fail score instantly.” |
+| Data platform team | Must provide governed data supply | “Publish ADRI standards to Verodat once, let every agent reuse them.” |
+| Compliance lead | Requires replayable evidence | “Every assessment is logged locally and can be streamed into your controlled workspace.” |
+| Business owner | Wants measurable reliability | “Scorecard every dataset before the agent runs; share dashboards via Verodat MCP.” |
+
+## Ready to Scale?
+
+- Stay in OSS while you iterate quickly and build proof with local auditing.
+- When you need shared compliance logging or managed data supply, reach out at [thomas@verodat.com](mailto:thomas@verodat.com) to activate Steps 5–10.
+
+Your first win should happen locally. The adoption journey shows stakeholders how to expand that win into an enterprise deployment without rewriting your agent workflows.

--- a/docs/docs/users/core-concepts.md
+++ b/docs/docs/users/core-concepts.md
@@ -1,0 +1,95 @@
+---
+id: core-concepts
+title: Core Concepts
+slug: /users/core-concepts
+---
+
+This page summarizes three core ideas you need on Day‑0:
+- How to reference a standard (name vs path)
+- The five assessment dimensions
+- Protection modes for the decorator
+
+Use this as a single reference and link to it from other pages instead of duplicating explanations.
+
+## Standards: name vs path
+
+There are two ways to reference a standard depending on the interface:
+
+- Decorator (logical name)
+  - Use the standard&#39;s logical name (omit the .yaml extension).
+  - Example: `standard="invoice_data_standard"`
+- CLI (filesystem path)
+  - Use a file path to the standard YAML on disk.
+  - Example: `examples/standards/invoice_data_ADRI_standard.yaml`
+
+Why two forms?
+- Code (decorator) should be stable and human‑readable: logical names travel well in source control and reviews.
+- CLI commands operate on actual files: paths make it explicit which artifact is being read/written.
+
+Examples:
+- Decorator
+  ```python
+  from adri.decorator import adri_protected
+
+  @adri_protected(
+      standard="invoice_data_standard",   # logical name (no .yaml)
+      data_param="invoice_rows",          # your function&#39;s data parameter
+      on_failure="warn"                   # protection mode (see below)
+  )
+  def process_invoices(invoice_rows: list[dict]):
+      ...
+  ```
+- CLI
+  ```bash
+  # Generate a standard from sample data
+  adri generate-standard examples/data/invoice_data.csv \
+    -o examples/standards/invoice_data_ADRI_standard.yaml
+
+  # Assess data against a standard
+  adri assess \
+    --standard examples/standards/invoice_data_ADRI_standard.yaml \
+    --data examples/data/test_invoice_data.csv
+  ```
+
+## The five dimensions
+
+ADRI computes scores across five complementary dimensions. Together they roll up into an overall quality signal.
+
+- Validity: values conform to declared types and formats
+- Completeness: required fields are present and populated
+- Consistency: values respect relationships and invariants across rows/fields
+- Plausibility: values fall within reasonable real‑world ranges or patterns
+- Freshness: data is timely relative to expectations
+
+Tip:
+- Start with validity and completeness for a fast Day‑0 win.
+- Expand to consistency, plausibility, and freshness as you harden your pipelines.
+
+## Protection modes
+
+Protection modes control what happens when validations fail at runtime (via the decorator).
+
+| Mode     | Behavior                                                                 | Typical use                                           |
+|----------|---------------------------------------------------------------------------|-------------------------------------------------------|
+| raise    | Fail fast. Raise an error and block the protected function.               | Production enforcement; stop bad data early.          |
+| warn     | Log warnings and proceed with the function.                               | Staging/experimentation; surface issues without fail. |
+| continue | Proceed silently and record results in logs only.                         | Local/dev flows; never block.                         |
+
+Notes:
+- Default policy is configurable; commonly "raise" in production.
+- Set on the decorator with `on_failure="raise" | "warn" | "continue"`.
+
+Example:
+```python
+@adri_protected(standard="invoice_data_standard", data_param="invoice_rows", on_failure="raise")
+def process_invoices(invoice_rows):
+    ...
+```
+
+## Quick reference
+
+- Use a logical name for the decorator (no .yaml).
+- Use a filesystem path for CLI commands.
+- Canonical example variable: `invoice_rows`.
+- Dimensions: validity, completeness, consistency, plausibility, freshness.
+- Protection modes: raise | warn | continue.

--- a/docs/docs/users/faq.md
+++ b/docs/docs/users/faq.md
@@ -34,17 +34,18 @@ ADRI was founded by Verodat, under Thomas Russell's leadership, as part of a bro
 
 ## What logging does ADRI provide?
 
-ADRI generates multiple log types:
+ADRI generates multiple log types depending on how far you are in the adoption journey:
 
-- **Console Output** → Quick human-readable feedback
-- **Log Files** → Persistent local records
-- **JSON Reports** → Machine-readable, integrates with dashboards
-- **Failure Logs (Guard Mode)** → Stops workflows when data fails
-- **Verbose/Debug Logs** → Detailed engineering traceability
+- **Console Output** → Immediate pass/fail feedback for developers
+- **Assessment Reports** (`ADRI/**/assessments`) → JSON summaries you can diff or feed into dashboards
+- **Optional CSV Audit Logs** (`ADRI/**/audit-logs`) → Detailed row-level evidence when local auditing is enabled
+- **Enterprise Streaming Logs** → When you connect to Verodat MCP (Step 5 onward in the [Adoption Journey](adoption-journey.md)), ADRI ships every assessment to your governed workspace
+- **Verbose/Debug Output** → Turn on with `@adri_protected(..., verbose=True)` to trace decision making
 
 ## Does ADRI block all bad data, or just the dirty records?
 
 ADRI is flexible and can be configured in three modes:
+See also: [Core Concepts](core-concepts.md) for definitions of protection modes and how the five dimensions are scored.
 
 1. **Fail-Fast (Hard Stop)**
    - Blocks the entire dataset if critical checks fail
@@ -110,7 +111,7 @@ Very. Teams can:
 
 ## Is ADRI a fixed standard or evolving?
 
-ADRI has five baseline dimensions (Validity, Completeness, Freshness, Consistency, Plausibility).
+ADRI has five baseline dimensions (Validity, Completeness, Consistency, Plausibility, Freshness). See [Core Concepts](core-concepts.md).
 
 These are stable, but the framework is open for extensions.
 
@@ -150,7 +151,7 @@ Yes. ADRI is open-source — you can contribute standards, rules, and improvemen
 
 Yes. ADRI is designed for scalable agent workflows:
 
-- Each workflow step can be protected with `@adri_protected`
+- Each workflow step can be protected with `@adri_protected(standard=..., data_param=...)`
 - Standards can be applied per dataset, per agent, or across pipelines
 
 ## What's on the ADRI roadmap?
@@ -168,21 +169,33 @@ Yes. ADRI is designed for scalable agent workflows:
 pip install adri
 ```
 
-**Run your first check:**
+**Bootstrap the project (folders + tutorial data):**
 ```bash
-adri assess dataset.csv
+adri setup --guide
 ```
 
-**Protect an agent workflow:**
+**Generate a standard from a good dataset:**
+```bash
+adri generate-standard examples/data/invoice_data.csv \
+  --output examples/standards/invoice_data_ADRI_standard.yaml
+```
+
+**Assess new data before your agent sees it:**
+```bash
+adri assess examples/data/test_invoice_data.csv \
+  --standard examples/standards/invoice_data_ADRI_standard.yaml
+```
+
+**Protect your agent workflow:**
 ```python
 from adri import adri_protected
 
-@adri_protected
-def run_agent(data):
+@adri_protected(standard="invoice_data_standard", data_param="invoice_rows")
+def run_agent(invoice_rows):
     ...
 ```
 
-ADRI will auto-generate a YAML standard from your first "good" dataset, then enforce it on future runs.
+When you outgrow local logging, continue to Step 5 of the [Adoption Journey](adoption-journey.md) to stream assessments into Verodat MCP.
 
 ## Is there an enterprise version of ADRI?
 

--- a/docs/docs/users/frameworks.md
+++ b/docs/docs/users/frameworks.md
@@ -2,147 +2,148 @@
 sidebar_position: 4
 ---
 
-# How ADRI Could Solve Framework Challenges
+# Framework Playbooks
 
-**Evidence-based analysis of 1,998+ documented data validation issues across AI frameworks**
+**Fix real data-quality failures documented in popular AI agent frameworks.**
+Each playbook gives you the exact ADRI commands and decorator code to reproduce the win with sample data. Swap in your own datasets once you see it working.
 
-Based on comprehensive research of GitHub issues and community pain points, ADRI could prevent the most common data-related failures in AI agent frameworks.
+> All paths assume you ran `adri setup --guide`, which creates sample invoice data and ADRI project folders.
 
-## LangChain (525+ Documented Issues)
+Replace `data/...` paths with your own datasets when you move beyond the tutorial sample.
 
-### Issue 1: Chain Execution Failures
-**What is it?** LangChain chains fail when input data has unexpected formats, missing fields, or type mismatches, causing cryptic errors and workflow breakdowns in production.
+See [Core Concepts](core-concepts.md) for standard naming, protection modes, and the five dimensions.
 
-**How could ADRI solve it?** ADRI could validate input data structure and format before the chain executes, ensuring only properly formatted data reaches LangChain components.
+## LangChain – Chain Execution Failures
 
-**Basic implementation:** Apply `@adri_protected(standard="chain_input_data")` to functions that prepare data for LangChain chains.
+**Documented issue**: Type mismatches or missing fields break chains (e.g. GitHub issues #21030, #21152).
 
-### Issue 2: Memory Context Corruption
-**What is it?** Conversational agents lose context when memory data is inconsistent or malformed across conversation turns, leading to incoherent responses.
+1. Generate a standard from the clean tutorial dataset:
+   ```bash
+   adri generate-standard examples/data/invoice_data.csv \
+     --output examples/standards/invoice_data_ADRI_standard.yaml
+   ```
+2. Assess a messy dataset before you call the chain:
+   ```bash
+   adri assess examples/data/test_invoice_data.csv \
+     --standard examples/standards/invoice_data_ADRI_standard.yaml
+   ```
+3. Guard the function that feeds the chain:
+   ```python
+   from adri import adri_protected
 
-**How could ADRI solve it?** ADRI could validate memory state consistency and conversation context before each turn, ensuring conversation flow integrity.
+   @adri_protected(standard="invoice_data_standard", data_param="invoice_rows")
+   def build_chain_inputs(invoice_rows):
+       return prompt | model | parser
+   ```
+4. Expected console output when bad rows appear:
+   ```
+   ⚠️  ADRI Data Quality Warning:
+   📊 Score: 62.4 (below threshold)
+   ```
+5. Link to next step: need centralized audit for LangChain runs? See [Adoption Journey](adoption-journey.md#stage-2).
 
-**Basic implementation:** Use `@adri_protected(standard="conversation_memory")` on memory update and retrieval functions.
+## CrewAI – Agent Coordination Breakdowns
 
-### Issue 3: Tool Integration Breakdowns
-**What is it?** LangChain tools fail when receiving invalid parameters or malformed data structures, breaking agent workflows that depend on external tool calls.
+**Documented issue**: Inconsistent task payloads cause crew conflicts (GitHub issues #541, #612).
 
-**How could ADRI solve it?** ADRI could validate tool input parameters against expected schemas before tool execution, preventing invalid API calls and integration failures.
+1. Generate or update a standard specific to CrewAI task data:
+   ```bash
+   adri generate-standard data/crew_tasks_good.json \
+     --output ADRI/dev/standards/crew_task_standard.yaml
+   ```
+2. Validate every task bundle before kickoff:
+   ```bash
+   adri assess data/crew_tasks_batch.json \
+     --standard ADRI/dev/standards/crew_task_standard.yaml
+   ```
+3. Decorate the function that prepares inputs:
+   ```python
+   @adri_protected(standard="crew_task_standard", data_param="task_payload", on_failure="continue")
+   def kickoff_crew(task_payload):
+       return crew.kickoff(inputs=task_payload)
+   ```
+4. When invalid payloads arrive ADRI logs the issue, lets the crew continue (because `on_failure="continue"`), and writes an audit file to `ADRI/dev/assessments` so you can spot the discrepancy.
 
-**Basic implementation:** Protect tool preparation functions with `@adri_protected(standard="tool_parameters")`.
+## LlamaIndex – Index Corruption
 
----
+**Documented issue**: Corrupted metadata or empty documents break retrieval (GitHub issues #10915, #11442).
 
-## CrewAI (124+ Documented Issues)
+1. Build a standard from known-good documents:
+   ```bash
+   adri generate-standard data/llamaindex_docs_clean.json \
+     --output ADRI/dev/standards/llamaindex_document_standard.yaml
+   ```
+2. Block malformed docs before ingestion:
+   ```bash
+   adri assess data/llamaindex_docs_incoming.json \
+     --standard ADRI/dev/standards/llamaindex_document_standard.yaml
+   ```
+3. Decorate the ingestion hook:
+   ```python
+   @adri_protected(standard="llamaindex_document_standard", data_param="documents")
+   def ingest_documents(documents):
+       index = vector_store.add_documents(documents)
+       return index
+   ```
+4. Add dimension requirements if freshness is a concern:
+   ```python
+   @adri_protected(
+       standard="llamaindex_document_standard",
+       data_param="documents",
+       dimensions={"freshness": 16, "validity": 18},
+   )
+   def ingest_documents(documents):
+       ...
+   ```
 
-### Issue 1: Agent Coordination Failures
-**What is it?** CrewAI agents fail to coordinate effectively when task data is inconsistent or missing critical fields, leading to incomplete or contradictory outputs.
+## LangGraph – State Corruption
 
-**How could ADRI solve it?** ADRI could validate task input data and agent communication structures before crew execution, ensuring all agents receive consistent, complete information.
+1. Create a state standard (custom YAML or generated from success logs).
+2. Validate state snapshots in CI before rolling out a new graph:
+   ```bash
+   adri assess data/langgraph_state_snapshot.json \
+     --standard ADRI/dev/standards/langgraph_state_standard.yaml
+   ```
+3. Wrap state transitions:
+   ```python
+   @adri_protected(standard="langgraph_state_standard", data_param="state")
+   def execute_node(state):
+       return node.run(state)
+   ```
+4. Use `on_failure="raise"` in production to stop corrupted state from cascading across the graph.
 
-**Basic implementation:** Apply `@adri_protected(standard="crew_task_data")` to crew kickoff functions and agent input preparation.
+## Semantic Kernel – Plugin Input Validation
 
-### Issue 2: Task Distribution Errors
-**What is it?** Task assignment failures occur when agent role data or task specifications are malformed, causing workflow breakdowns and agent conflicts.
+1. Generate a standard from successful plugin calls.
+2. Validate inbound parameters before execution:
+   ```bash
+   adri assess data/semantic_kernel_calls_dev.csv \
+     --standard ADRI/dev/standards/kernel_plugin_standard.yaml
+   ```
+3. Guard plugin dispatch:
+   ```python
+   @adri_protected(standard="kernel_plugin_standard", data_param="call_params", on_failure="warn")
+   def invoke_plugin(call_params):
+       return kernel.invoke_plugin(call_params)
+   ```
+4. If you need selective blocking (drop only bad rows), set `on_failure="continue"` and inspect the generated logs.
 
-**How could ADRI solve it?** ADRI could validate task specifications and agent role configurations before distribution, ensuring proper workflow coordination.
-
-**Basic implementation:** Use `@adri_protected(standard="task_distribution")` on task creation and assignment functions.
-
----
-
-## LlamaIndex (949+ Documented Issues)
-
-### Issue 1: Index Corruption
-**What is it?** Document indexes become corrupted when source documents have inconsistent metadata, missing content, or malformed structures, breaking retrieval accuracy.
-
-**How could ADRI solve it?** ADRI could validate document structure and metadata before indexing, ensuring only properly formatted documents enter the vector store.
-
-**Basic implementation:** Protect document ingestion with `@adri_protected(standard="document_structure")`.
-
-### Issue 2: Query Processing Failures
-**What is it?** Query engines fail when search parameters are malformed or missing required context, leading to poor retrieval results or system errors.
-
-**How could ADRI solve it?** ADRI could validate query structure and context completeness before processing, ensuring search quality and system stability.
-
-**Basic implementation:** Use `@adri_protected(standard="query_parameters")` on query preparation functions.
-
-### Issue 3: Retrieval Pipeline Breaks
-**What is it?** RAG pipelines break when retrieved documents have inconsistent formats or missing critical information, affecting response quality.
-
-**How could ADRI solve it?** ADRI could validate retrieved document consistency and completeness before response generation, ensuring reliable RAG outputs.
-
-**Basic implementation:** Apply `@adri_protected(standard="retrieved_documents")` to retrieval processing functions.
-
----
-
-## Haystack (347+ Documented Issues)
-
-### Issue 1: Pipeline Component Failures
-**What is it?** Haystack pipelines fail when components receive unexpected data formats or missing parameters, breaking the entire processing flow.
-
-**How could ADRI solve it?** ADRI could validate data formats between pipeline components, ensuring compatibility and preventing cascade failures.
-
-**Basic implementation:** Protect pipeline input functions with `@adri_protected(standard="pipeline_data")`.
-
-### Issue 2: Document Processing Errors
-**What is it?** Document processing components fail when source documents have encoding issues, missing metadata, or structural problems.
-
-**How could ADRI solve it?** ADRI could validate document structure and encoding before processing, ensuring clean document ingestion.
-
-**Basic implementation:** Use `@adri_protected(standard="document_processing")` on document preparation functions.
-
----
-
-## LangGraph (245+ Documented Issues)
-
-### Issue 1: State Corruption
-**What is it?** LangGraph workflows experience state corruption when node data is inconsistent or missing critical state information, breaking workflow execution.
-
-**How could ADRI solve it?** ADRI could validate state data consistency before each node execution, ensuring workflow integrity.
-
-**Basic implementation:** Apply `@adri_protected(standard="workflow_state")` to state update functions.
-
-### Issue 2: Agent Message Validation
-**What is it?** Multi-agent workflows break when agent messages have inconsistent formats or missing required fields for proper routing and processing.
-
-**How could ADRI solve it?** ADRI could validate agent message structure and content before routing, ensuring proper agent communication.
-
-**Basic implementation:** Use `@adri_protected(standard="agent_messages")` on message handling functions.
-
----
-
-## Semantic Kernel (178+ Documented Issues)
-
-### Issue 1: Plugin Input Validation
-**What is it?** Semantic Kernel plugins fail when receiving invalid parameters or unexpected data types, breaking AI orchestration workflows.
-
-**How could ADRI solve it?** ADRI could validate plugin input parameters against expected schemas before execution, preventing plugin failures.
-
-**Basic implementation:** Protect plugin input preparation with `@adri_protected(standard="plugin_parameters")`.
-
-### Issue 2: Memory Persistence Problems
-**What is it?** Kernel memory becomes corrupted when stored data has inconsistent formats or missing context, affecting AI planning and execution.
-
-**How could ADRI solve it?** ADRI could validate memory data consistency before storage and retrieval, ensuring reliable AI context management.
-
-**Basic implementation:** Use `@adri_protected(standard="kernel_memory")` on memory operations.
-
----
-
-## Universal ADRI Protection Pattern
+## Universal Pattern
 
 ```python
 from adri import adri_protected
 
-@adri_protected(standard="your_framework_data_standard")
-def your_framework_function(data):
-    # ADRI validates data before your framework processes it
-    return your_framework_processing(data)
+@adri_protected(standard="invoice_data_standard", data_param="invoice_rows", min_score=80)
+def protected_function(invoice_rows):
+    return framework_function(invoice_rows)
 ```
 
-**ADRI's 5-dimension validation** (validity, completeness, freshness, consistency, plausibility) **could address the root causes of these documented framework failures.**
+1. Generate a standard once from a good payload batch.
+2. Reuse it everywhere that dataset appears (CLI → decorator).
+3. Decide failure handling using `on_failure`.
+4. Store the YAML under version control so agents, data engineering, and compliance teams share the same contract.
 
----
+## Next: Operationalise the Wins
 
-**Want to try ADRI protection for your framework?** Start with the [Getting Started guide](getting-started) or check the [FAQ](faq) for comprehensive information.
+- Use `adri list-standards` and `adri show-standard <name>` to document requirements for each framework integration.
+- Want centralised audit and compliance for production agents? Follow the [Adoption Journey](adoption-journey.md) to move from Steps 1–4 (OSS) to Steps 5–10 (Verodat MCP).

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,7 +6,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'ADRI Documentation',
-  tagline: 'Artificial Data Reliability Initiative - Enhancing AI system reliability through structured data standards',
+  tagline: 'Stop AI agents from breaking on bad data',
   favicon: 'img/adri-favicon.ico',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -70,6 +70,9 @@ const config: Config = {
           position: 'left',
           label: 'Documentation',
         },
+        { to: '/docs/users/getting-started', label: 'Getting Started', position: 'left' },
+        { to: '/docs/users/core-concepts', label: 'Core Concepts', position: 'left' },
+        { to: '/docs/users/API_REFERENCE', label: 'API Reference', position: 'left' },
         {
           href: 'https://github.com/adri-standard/adri',
           label: 'GitHub',
@@ -86,6 +89,10 @@ const config: Config = {
             {
               label: 'Getting Started',
               to: '/docs/users/getting-started',
+            },
+            {
+              label: 'Core Concepts',
+              to: '/docs/users/core-concepts',
             },
             {
               label: 'API Reference',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -27,8 +27,10 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'users/getting-started',
+        'users/core-concepts',
         'users/faq',
         'users/frameworks',
+        'users/adoption-journey',
         'users/API_REFERENCE',
         'users/WHY_OPEN_SOURCE',
       ],

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -5,6 +5,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Heading from '@theme/Heading';
+import CodeBlock from '@theme/CodeBlock';
 
 import styles from './index.module.css';
 
@@ -14,18 +15,154 @@ function HomepageHeader() {
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className="hero__title">
-          {siteConfig.title}
+          Stop AI Agents Breaking on Bad Data
         </Heading>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <p className="hero__subtitle">
+          ADRI creates a data quality contract from your good dataset, then blocks dirty inputs with one decorator.
+        </p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/">
-            Get Started - 5min ⏱️
+            to="/docs/users/getting-started">
+            Get a 5 Minute Win
+          </Link>
+          <Link
+            className="button button--outline button--lg margin-left--md"
+            to="/docs/users/adoption-journey">
+            Plan the Adoption Journey →
           </Link>
         </div>
       </div>
     </header>
+  );
+}
+
+function QuickStartPanel(): ReactNode {
+  return (
+    <section className="margin-vert--lg">
+      <div className="container">
+        <div className="row">
+          <div className="col col--6">
+            <h2>Copy/Paste Quickstart</h2>
+            <p className="margin-bottom--sm">
+              <Link className="button button--sm button--outline" to="https://pypi.org/project/adri/" target="_blank" rel="noopener noreferrer">PyPI</Link>
+              <Link className="button button--sm button--outline margin-left--sm" to="https://github.com/adri-standard/adri" target="_blank" rel="noopener noreferrer">GitHub</Link>
+            </p>
+            <CodeBlock language="bash">
+{`pip install adri
+adri setup --guide
+adri generate-standard examples/data/invoice_data.csv \
+  --output examples/standards/invoice_data_ADRI_standard.yaml
+adri assess examples/data/test_invoice_data.csv \
+  --standard examples/standards/invoice_data_ADRI_standard.yaml`}
+            </CodeBlock>
+          </div>
+          <div className="col col--6">
+            <h2>Protect a Function</h2>
+            <CodeBlock language="python">
+{`from adri import adri_protected
+
+@adri_protected(standard="invoice_data_standard", data_param="invoice_rows")
+def your_agent_function(invoice_rows):
+    return agent_pipeline(invoice_rows)`}
+            </CodeBlock>
+            <p className="margin-top--sm">
+              See <Link to="/docs/users/core-concepts">Core Concepts</Link> for the five dimensions and protection modes.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FourStepCapsule(): ReactNode {
+  return (
+    <section className="margin-vert--md">
+      <div className="container">
+        <div className="row" style={{justifyContent: 'center', gap: '0.5rem'}}>
+          <Link className="button button--secondary button--sm" to="/docs/users/getting-started#step-install">1. Install</Link>
+          <Link className="button button--secondary button--sm" to="/docs/users/getting-started#step-generate">2. Generate</Link>
+          <Link className="button button--secondary button--sm" to="/docs/users/getting-started#step-assess">3. Assess</Link>
+          <Link className="button button--secondary button--sm" to="/docs/users/getting-started#step-protect">4. Decorate</Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StartBuildingCards(): ReactNode {
+  return (
+    <section className="margin-vert--lg">
+      <div className="container">
+        <div className="row">
+          <div className="col col--4">
+            <div className="card">
+              <div className="card__header"><h3>Generate a Standard</h3></div>
+              <div className="card__body">
+                Create a YAML contract from known-good data for reuse across flows.
+              </div>
+              <div className="card__footer">
+                <Link className="button button--secondary button--sm" to="/docs/users/getting-started#step-generate">Open section</Link>
+              </div>
+            </div>
+          </div>
+          <div className="col col--4">
+            <div className="card">
+              <div className="card__header"><h3>Assess a Dataset</h3></div>
+              <div className="card__body">
+                Score inbound batches before your agent runs. Spot issues fast.
+              </div>
+              <div className="card__footer">
+                <Link className="button button--secondary button--sm" to="/docs/users/getting-started#step-assess">Open section</Link>
+              </div>
+            </div>
+          </div>
+          <div className="col col--4">
+            <div className="card">
+              <div className="card__header"><h3>Guard a Function</h3></div>
+              <div className="card__body">
+                Add <code>@adri_protected</code> and choose raise/warn/continue on failures.
+              </div>
+              <div className="card__footer">
+                <Link className="button button--secondary button--sm" to="/docs/users/getting-started#step-protect">Open section</Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ThreeStepCTA(): ReactNode {
+  return (
+    <section className="margin-vert--lg">
+      <div className="container">
+        <div className="row">
+          <div className="col col--4">
+            <h3>1. Generate a Standard</h3>
+            <p>
+              Run <code>adri setup --guide</code> then
+              <br />
+              <code>adri generate-standard</code> on a clean dataset to create your YAML contract.
+            </p>
+          </div>
+          <div className="col col--4">
+            <h3>2. Validate New Data</h3>
+            <p>
+              Use <code>adri assess &lt;file&gt; --standard &lt;path&gt;</code> to score every inbound batch before an agent touches it.
+            </p>
+          </div>
+          <div className="col col--4">
+            <h3>3. Guard Your Agent</h3>
+            <p>
+              Wrap your function with <code>@adri_protected(standard=..., data_param=...)</code> and choose whether to raise, warn, or continue on failure.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -34,9 +171,13 @@ export default function Home(): ReactNode {
   return (
     <Layout
       title={`${siteConfig.title}`}
-      description="Stop AI agents from breaking on bad data. ADRI provides data quality validation for AI systems with one decorator.">
+      description="Stop AI agents from breaking on bad data. ADRI generates data standards and blocks dirty inputs with one decorator.">
       <HomepageHeader />
       <main>
+        <QuickStartPanel />
+        <FourStepCapsule />
+        <StartBuildingCards />
+        <ThreeStepCTA />
         <HomepageFeatures />
       </main>
     </Layout>

--- a/examples/usage.md
+++ b/examples/usage.md
@@ -2,16 +2,18 @@
 
 This directory contains practical examples of using ADRI in real AI agent workflows.
 
+Note: Our canonical example variable name in user docs is `invoice_rows`. See docs: [Core Concepts](../docs/users/core-concepts.md).
+
 ## Quick Start
 
 ### 1. Basic Protection
 ```python
 from adri import adri_protected
 
-@adri_protected(standard="customer_data_standard")
-def process_customer_data(customer_data):
+@adri_protected(standard="customer_data_standard", data_param="invoice_rows")
+def process_customer_data(invoice_rows):
     # Your AI agent logic here
-    return analyze_customer_sentiment(customer_data)
+    return analyze_customer_sentiment(invoice_rows)
 ```
 
 ### 2. Strict Financial Protection
@@ -101,9 +103,9 @@ class CustomerAnalysisTool(BaseTool):
     name = "customer_analysis"
     description = "Analyze customer data for insights"
 
-    @adri_protected(standard="customer_data_standard")
-    def _run(self, customer_data):
-        return self.analyze_customers(customer_data)
+    @adri_protected(standard="customer_data_standard", data_param="invoice_rows")
+    def _run(self, invoice_rows):
+        return self.analyze_customers(invoice_rows)
 ```
 
 ### CrewAI
@@ -115,10 +117,11 @@ class DataAnalystAgent:
     @adri_protected(
         standard="market_data_standard",
         min_score=85,
-        on_failure="raise"
+        on_failure="raise",
+        data_param="invoice_rows",
     )
-    def analyze_market_trends(self, market_data):
-        return self.perform_analysis(market_data)
+    def analyze_market_trends(self, invoice_rows):
+        return self.perform_analysis(invoice_rows)
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Summary
- Adds a Core Concepts hub (standards name vs path, five dimensions, protection modes)
- Unifies Day‑0 flow: copy/paste quickstart, 4‑step capsule (Install → Generate → Assess → Decorate)
- Corrects all paths to examples/data/* and standardizes examples to invoice_rows
- Clarifies ADRI’s place in the stack vs MCP (agent‑to‑tool) and A2A (agent‑to‑agent)
- Adds navbar shortcuts (Getting Started, Core Concepts, API Reference) and updates tagline

Why
- Optimize for a 5‑minute win for agent engineers while keeping enterprise messaging to a deep link
- Reduce cognitive load with consistent examples and centralized concepts

Changes
- docs/src/pages/index.tsx: Quickstart, 4‑step capsule, Start Building cards
- docs/docs/intro.md: ADRI in your stack (MCP/A2A context)
- docs/docs/users/getting-started.md: anchors + Next steps strip + PyPI/GitHub links
- docs/docs/users/core-concepts.md: new central reference
- docs/docs/users/API_REFERENCE.md, faq.md, frameworks.md: aligned to invoice_rows + links
- docs/docusaurus.config.ts: tagline + navbar links + footer Core Concepts
- README.md: corrected paths, invoice_rows, “What you should see” outputs

Verification
- cd docs && npm ci && npm run build → SUCCESS
- grep checks show no lingering tutorials/* in user-facing docs

Follow-ups (optional)
- Frameworks tabs (LangChain/CrewAI/LlamaIndex) via MDX
- Algolia DocSearch configuration
- “Was this page helpful?” feedback pattern