### PR TITLE
docs: correct ADRI expansion + simplify homepage

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 # ADRI Documentation
 
-**Agent Data Reliability Intelligence – Stop AI agents from breaking on bad data**
+**Agent Data Readiness Index – Stop AI agents from breaking on bad data**
 
 ADRI is an open-source data quality validation framework built for AI agents. Generate a standard from good data once, wrap your functions with `@adri_protected`, and block dirty payloads before they crash your agents.
 

--- a/docs/docs/users/faq.md
+++ b/docs/docs/users/faq.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 ## What is ADRI?
 
-ADRI stands for **Agent Data Reliability Intelligence**. It is an open-source standard and toolset that evaluates how ready a dataset is for use by AI agents. ADRI ensures that data is valid, complete, fresh, consistent, and plausible before agents use it. This improves agent reliability, reduces errors, and prevents wasted cycles.
+ADRI stands for **Agent Data Readiness Index**. It is an open-source standard and toolset that evaluates how ready a dataset is for use by AI agents. ADRI ensures that data is valid, complete, fresh, consistent, and plausible before agents use it. This improves agent reliability, reduces errors, and prevents wasted cycles.
 
 ## Why was ADRI created?
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -176,9 +176,6 @@ export default function Home(): ReactNode {
       <main>
         <QuickStartPanel />
         <FourStepCapsule />
-        <StartBuildingCards />
-        <ThreeStepCTA />
-        <HomepageFeatures />
       </main>
     </Layout>
   );


### PR DESCRIPTION
Branding\n- Update long-form expansion to Agent Data Readiness Index in intro and FAQ\n\nHomepage simplification\n- Keep Hero + Quickstart + 4-step capsule\n- Remove secondary cards/CTAs to reduce cognitive load on Day‑0\n\nBuild\n- Local docusaurus build passes (npm run build)\n\nNotes\n- TRADEMARK and legal pages already used Agent Data Readiness Index\n- Repo tagline remains concise ('Stop AI agents from breaking on bad data'), consistent with homepage.