### PR TITLE
docs: fix Mermaid parse error on Adoption Journey

### DIFF
--- a/docs/docs/users/adoption-journey.md
+++ b/docs/docs/users/adoption-journey.md
@@ -32,7 +32,7 @@ flowchart LR
   D[Dataset] --> Assess[ADRI Assess]
   Assess -->|ALLOW| Func[Your Function]
   Assess -->|BLOCK| Stop[Prevent execution]
-  Assess --> LogsLocal[Local Logs (CSV/JSON under ADRI/**)]
+  Assess --> LogsLocal[Local Logs (CSV/JSON under ADRI folders)]
   Assess --> LogsEnt[Enterprise Logs (Verodat Workspace)]
   LogsLocal -. optional .-> Reports[Developer review]
   LogsEnt -. optional .-> Governance[Compliance dashboards]


### PR DESCRIPTION
Replace problematic 'ADRI/**' token in mermaid node label with plain text to avoid parser error on published site.\n\nChange:\n- LogsLocal[Local Logs (CSV/JSON under ADRI/**)] → LogsLocal[Local Logs (CSV/JSON under ADRI folders)]\n\nPlease approve to deploy the fix to GitHub Pages.