### PR TITLE
docs: fix Mermaid label on Adoption Journey (publish-safe)

### DIFF
--- a/docs/docs/users/adoption-journey.md
+++ b/docs/docs/users/adoption-journey.md
@@ -32,8 +32,8 @@ flowchart LR
   D[Dataset] --> Assess[ADRI Assess]
   Assess -->|ALLOW| Func[Your Function]
   Assess -->|BLOCK| Stop[Prevent execution]
-  Assess --> LogsLocal[Local Logs (CSV/JSON under ADRI folders)]
-  Assess --> LogsEnt[Enterprise Logs (Verodat Workspace)]
+  Assess --> LogsLocal[Local Logs]
+  Assess --> LogsEnt[Enterprise Logs]
   LogsLocal -. optional .-> Reports[Developer review]
   LogsEnt -. optional .-> Governance[Compliance dashboards]
 ```


### PR DESCRIPTION
Simplify Mermaid labels to avoid parser edge cases on GitHub Pages.\n\nBefore:\n- LogsLocal[Local Logs (CSV/JSON under ADRI folders)]\nAfter:\n- LogsLocal[Local Logs]\n- LogsEnt[Enterprise Logs]\n\nPlease approve to deploy fix and clear the page parse error.