### PR TITLE
Hotfix: Fix release workflow Windows compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Test wheel installation
       run: |
         python -c "import os; print('Available files:'); [print(f'  {f}') for f in os.listdir('dist')]"
-        pip install dist/adri-*.whl
+        python -c "import os, glob; wheel = glob.glob('dist/adri-*.whl')[0]; os.system(f'pip install {wheel}')"
 
     - name: Test CLI functionality
       run: |


### PR DESCRIPTION
## Critical Hotfix for v4.1.0 Release

This PR fixes a critical issue in the release workflow that caused all Windows test installations to fail.

### Problem
The command `pip install dist/adri-*.whl` uses shell wildcard expansion which doesn't work on Windows PowerShell, causing the release workflow to fail.

### Solution
Replace shell wildcard with Python glob for cross-platform compatibility:
```python
python -c "import os, glob; wheel = glob.glob('dist/adri-*.whl')[0]; os.system(f'pip install {wheel}')"
```

### Impact
- Fixes wheel installation on Windows, macOS, and Linux
- Enables successful v4.1.0 release
- Required before recreating the v4.1.0 tag

### Testing
- ✅ Python glob works consistently across all platforms
- ✅ Matches existing pattern in workflow

**Priority: Critical** - Blocking v4.1.0 release