### PR TITLE
Hotfix: Remove Unicode emoji from release workflow tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,15 +139,15 @@ jobs:
       run: |
         python -c "
         import adri
-        print(f'✅ Successfully imported ADRI version: {adri.__version__}')
+        print(f'Successfully imported ADRI version: {adri.__version__}')
 
         # Verify version matches expectation
         expected = '${{ needs.validate-tag.outputs.version }}'
         if adri.__version__ != expected:
-            print(f'❌ Version mismatch: {adri.__version__} != {expected}')
+            print(f'Version mismatch: {adri.__version__} != {expected}')
             exit(1)
 
-        print('✅ Version verification passed')
+        print('Version verification passed')
         "
 
   publish-test-pypi:


### PR DESCRIPTION
## Critical Hotfix for v4.1.0 Release - Part 2

This PR fixes Unicode encoding errors in the release workflow test scripts that caused Windows test failures.

### Problem
Windows PowerShell cannot encode Unicode emoji characters (✅/❌) in test output:
```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2705'
```

### Solution
Replace Unicode emoji with plain text in test output:
- ✅ → "Successfully" / "passed"
- ❌ → "Version mismatch"

### Impact
- Fixes all Windows test failures
- Ensures consistent output across platforms
- Completes the v4.1.0 release workflow

### Testing
- Plain ASCII text works on all platforms
- Previous test run: 5/9 passed (Ubuntu + macOS worked)
- With this fix: All 9 platform/Python combinations should pass

**Priority: Critical** - Final blocker for v4.1.0 release