### PR TITLE
chore: update CHANGELOG for v4.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 No unreleased changes.
 
-## [4.1.1] - 2025-06-10
+## [4.1.2] - 2025-06-10
+
+**Note:** This release supersedes v4.1.1 due to release workflow issues. Functionality is identical.
 
 ### Fixed
 - **Issue #35 Regression**: Restored CLI/Decorator parity after test consolidation


### PR DESCRIPTION
## Summary
Updates CHANGELOG.md from v4.1.1 to v4.1.2

## Reason
v4.1.1 was successfully published to PyPI but the release workflow failed on TestPyPI (version already existed). Rather than yanking v4.1.1, we're proceeding with v4.1.2 as the tagged release.

## Changes
- Changed version header from 4.1.1 to 4.1.2
- Added note explaining that v4.1.2 supersedes v4.1.1 due to release workflow issues
- Functionality remains identical to v4.1.1

## Next Steps
After merging:
1. Create v4.1.2 tag from main
2. Push tag to trigger release workflow
3. v4.1.2 will publish to PyPI as latest version