### PR TITLE
fix: improve TestPyPI validation with proper wait time and tutorial tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+
     - name: Download build artifacts
       uses: actions/download-artifact@v5
       with:
@@ -169,9 +173,17 @@ jobs:
 
     - name: Test installation from TestPyPI
       run: |
-        sleep 60  # Wait for package to be available
+        sleep 180  # Wait for TestPyPI CDN propagation (typically 2-3 minutes)
         pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ adri==${{ needs.validate-tag.outputs.version }}
         adri --version
+
+    - name: Run tutorial tests against TestPyPI package
+      run: |
+        # Install test dependencies
+        pip install pytest pytest-cov
+
+        # Run all tutorial tests to validate real-world usage
+        pytest tests/test_tutorial_*.py -v --tb=short
 
   publish-pypi:
     needs: [validate-tag, build, test-install, publish-test-pypi]


### PR DESCRIPTION
## Problem
The v4.1.2 release workflow failed because:
1. **60 seconds wasn't enough** for TestPyPI CDN propagation (typically 2-3 minutes)
2. **No real-world validation** before production PyPI publication

## Solution
This PR fixes both issues while **keeping TestPyPI as a blocking quality gate**:

### Changes
1. ✅ **Increase wait time: 60s → 180s**
   - Allows proper TestPyPI CDN propagation
   - Matches typical 2-3 minute propagation time
   
2. ✅ **Add tutorial tests to TestPyPI validation**
   - Runs all `test_tutorial_*.py` tests
   - Validates real-world usage scenarios
   - Catches integration issues before production
   
3. ✅ **Add checkout step**
   - Needed to access test files
   
4. ✅ **Keep TestPyPI blocking**
   - Still catches real errors (metadata, dependencies, imports)
   - Proper quality gate before production PyPI

## Testing Strategy
After TestPyPI upload, the workflow will:
1. Wait 180s for CDN propagation
2. Install package from TestPyPI
3. Verify CLI works (`adri --version`)
4. **NEW:** Run all tutorial tests to validate end-to-end functionality

## Impact
- ✅ Fixes v4.1.2 release workflow
- ✅ Adds comprehensive pre-production validation
- ✅ Maintains quality gate integrity
- ⏱️ Adds ~2 minutes to release time (acceptable tradeoff)

## Next Steps
After merge:
1. Re-trigger v4.1.2 release by deleting and re-pushing tag
2. Monitor improved TestPyPI validation
3. Verify successful PyPI publication