### PR TITLE
fix: add pytest-timeout to release workflow dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
     - name: Run tutorial tests against TestPyPI package
       run: |
         # Install test dependencies
-        pip install pytest pytest-cov
+        pip install pytest pytest-cov pytest-timeout
 
         # Run all tutorial tests to validate real-world usage
         pytest tests/test_tutorial_*.py -v --tb=short


### PR DESCRIPTION
## Critical Fixes for v4.1.4 Release

This PR contains essential fixes to enable the v4.1.4 release:

### 1. Release Workflow Fix (pytest-timeout)
**Problem:** v4.1.3 release failed with 

**Solution:** Install  in TestPyPI validation step
Looking in indexes: https://user:****@pkgs.safetycli.com/repository/public/pypi/simple/
Requirement already satisfied: pytest in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (8.4.1)
Requirement already satisfied: pytest-cov in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (6.2.1)
Requirement already satisfied: pytest-timeout in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (2.4.0)
Requirement already satisfied: iniconfig>=1 in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (from pytest) (2.1.0)
Requirement already satisfied: packaging>=20 in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (from pytest) (24.2)
Requirement already satisfied: pluggy<2,>=1.5 in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (from pytest) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (from pytest) (2.19.2)
Requirement already satisfied: coverage>=7.5 in /Users/thomas/.pyenv/versions/3.12.7/lib/python3.12/site-packages (from coverage[toml]>=7.5->pytest-cov) (7.9.1)

### 2. Smart CI Implementation
**Problem:** Full CI runs (~10 min) for CHANGELOG-only PRs waste resources

**Solution:** Intelligent change detection
- **Documentation-only PRs**: Lightweight validation (~1 min)
  - Detects: CHANGELOG.md, README.md, docs/*, LICENSE, etc.
  - Runs: Structure validation, .gitignore checks
  - Skips: Full test suite, security scans, build tests
  
- **Code changes**: Full CI (~10 min)
  - Any non-docs file triggers complete test suite
  - Pipeline changes (.github/workflows) trigger full CI
  - Maintains all safety checks

### 3. Version Bump to v4.1.4
**Why v4.1.4?** v4.1.3 tag already exists with workflow issues

**Changes:**
- Updated CHANGELOG.md: v4.1.3 → v4.1.4
- Core functionality identical to v4.1.1
- Python 3.13 support included
- Clean release path

## Benefits

✅ **Unblocks v4.1.4 release** - Fixes TestPyPI validation  
✅ **Reduces CI overhead** - Fast path for docs-only PRs  
✅ **Maintains safety** - Full CI for code and pipeline changes  
✅ **Smart automation** - Respects branch protection rules  

## Testing Strategy

This PR will demonstrate the smart CI:
- Contains CHANGELOG.md update (docs-only)
- Also contains .github/workflows/ci.yml (pipeline change)
- **Result:** Full CI will run (correct behavior for pipeline changes)

Future CHANGELOG-only PRs will run lightweight validation only.

## After Merge

1. Update local main: `git checkout main && git pull`
2. Create v4.1.4 tag
3. Push tag to trigger release
4. Monitor successful PyPI publication

**Urgency: HIGH** - Enables v4.1.4 release with improved workflow