### PR TITLE
fix: add contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,8 @@ jobs:
   create-github-release:
     needs: [validate-tag, build, test-install, publish-pypi]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create releases
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
## Problem

The GitHub release creation step in the release workflow fails with:
```
Error: Resource not accessible by integration
```

This happened during the v4.1.4 release process.

## Root Cause

The `create-github-release` job uses `actions/create-release@v1` which requires `contents: write` permission to create GitHub releases, but this permission was not explicitly granted.

## Solution

Added explicit permissions to the `create-github-release` job:
```yaml
permissions:
  contents: write  # Required to create releases
```

## Testing

This fix will be validated in the next release (v4.1.5 or later). The v4.1.4 release was completed manually using `gh release create`.

## Impact

- ✅ Fixes automated GitHub release creation
- ✅ No breaking changes
- ✅ Future releases will complete end-to-end automatically
- ✅ Maintains compatibility with existing workflow

## Related

- Release workflow: `.github/workflows/release.yml`
- Completed v4.1.4 release: https://github.com/adri-standard/adri/releases/tag/v4.1.4