### PR TITLE
feat: Add optional artifact_declaration section to ADRI contracts (v7.3.0)

### DIFF
--- a/ADRI/contracts/artifact_declaration_example.yaml
+++ b/ADRI/contracts/artifact_declaration_example.yaml
@@ -1,0 +1,63 @@
+# Example: ADRI Contract with Single Artifact Declaration
+# This demonstrates the singular artifact_declaration form.
+# The artifact declaration tells downstream consumers what the validated
+# output IS — a report, UI component, dataset push, notification, etc.
+#
+# New in ADRI v7.3.0. See RFC #100 on adri-standard/adri.
+
+contracts:
+  id: "api-quality-report"
+  name: "API Response Quality Report"
+  version: "1.0.0"
+  description: "Validates API response data and produces a quality report artifact"
+
+record_identification:
+  primary_key_fields:
+    - response_id
+  strategy: "unique"
+
+requirements:
+  overall_minimum: 80.0
+  field_requirements:
+    response_id:
+      type: string
+      nullable: false
+    status_code:
+      type: integer
+      nullable: false
+      min_value: 100
+      max_value: 599
+    response_time_ms:
+      type: number
+      nullable: false
+      min_value: 0
+    endpoint:
+      type: string
+      nullable: false
+  dimension_requirements:
+    validity:
+      weight: 3
+      minimum_score: 80
+    completeness:
+      weight: 3
+      minimum_score: 90
+    consistency:
+      weight: 2
+    freshness:
+      weight: 1
+    plausibility:
+      weight: 1
+
+# Artifact Declaration: What the validated output IS FOR
+artifact_declaration:
+  type: report
+  render_hints:
+    format: markdown
+    template: "api_quality_summary"
+    title: "API Response Quality Report"
+  channel_compatibility:
+    - cli
+    - slack
+    - web_dashboard
+    - email
+  lifecycle: ephemeral

--- a/ADRI/contracts/multi_artifact_example.yaml
+++ b/ADRI/contracts/multi_artifact_example.yaml
@@ -1,0 +1,89 @@
+# Example: ADRI Contract with Multiple Artifact Declarations
+# This demonstrates the plural artifact_declarations form (array).
+# A single contract can produce multiple artifacts for different channels.
+#
+# New in ADRI v7.3.0. See RFC #100 on adri-standard/adri.
+
+contracts:
+  id: "customer-data-pipeline"
+  name: "Customer Data Quality Pipeline"
+  version: "1.0.0"
+  description: "Validates customer data and produces multiple artifacts"
+
+requirements:
+  overall_minimum: 85.0
+  field_requirements:
+    customer_id:
+      type: string
+      nullable: false
+    email:
+      type: string
+      nullable: false
+      pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+    name:
+      type: string
+      nullable: false
+    signup_date:
+      type: string
+      nullable: true
+  dimension_requirements:
+    validity:
+      weight: 3
+    completeness:
+      weight: 3
+    consistency:
+      weight: 2
+    freshness:
+      weight: 1
+    plausibility:
+      weight: 1
+
+# Multiple Artifact Declarations
+artifact_declarations:
+  # 1. Quality report for human review
+  - type: report
+    render_hints:
+      format: markdown
+      template: "customer_quality_report"
+    channel_compatibility:
+      - cli
+      - slack
+    lifecycle: ephemeral
+
+  # 2. Interactive dashboard component (A2UI-compatible)
+  - type: ui_component
+    render_hints:
+      format: a2ui_json
+      component_type: "quality_scorecard"
+      interactive: true
+    channel_compatibility:
+      - web_dashboard
+    lifecycle: persistent
+    retention_days: 90
+
+  # 3. Push validated data to downstream store
+  - type: dataset_push
+    render_hints:
+      format: json
+      target: "validated_customers"
+    lifecycle: persistent
+    retention_days: 365
+
+  # 4. Alert on quality issues
+  - type: notification
+    render_hints:
+      format: text
+      severity_threshold: "WARNING"
+    channel_compatibility:
+      - slack
+      - email
+    lifecycle: ephemeral
+
+  # 5. Custom platform-specific artifact
+  - type: x-custom-verodat-sync
+    render_hints:
+      format: json
+      workspace_id: 123
+      dataset_id: 456
+    lifecycle: persistent
+    retention_days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to ADRI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.0] - 2026-03-27
+
+**Feature Release: Artifact Declaration — Protocol Compatibility with A2UI, MCP, A2A**
+
+This release adds optional `artifact_declaration` / `artifact_declarations` sections to ADRI contracts, enabling protocol compatibility with A2UI, MCP, WebMCP, and A2A. ADRI contracts can now declare what validated data outputs are FOR — reports, UI components, dataset pushes, notifications, etc. This is a non-breaking, fully backward-compatible addition.
+
+Addresses RFC Discussion #100 and Feature Issue #101 on upstream `adri-standard/adri`.
+
+### Added
+- **Artifact Declaration**: New optional contract section declaring output artifact types and rendering metadata
+  - Singular form: `artifact_declaration` (dict) for single artifacts
+  - Plural form: `artifact_declarations` (list) for multiple artifacts from one contract
+  - Both forms are mutually exclusive; singular is treated as single-element array internally
+- **7 Core Artifact Types**: `report`, `ui_component`, `dataset_push`, `notification`, `config_update`, `scaffold`, `certification_evidence`
+- **Custom Type Extension**: `x-custom-*` prefix pattern for platform-specific artifact types
+- **5 Render Formats**: `markdown`, `json`, `html`, `a2ui_json`, `text` — validated in `render_hints.format`
+- **Lifecycle Management**: `ephemeral` (run-scoped, default) and `persistent` (outlives run, optional `retention_days`)
+- **`ArtifactDeclaration` Dataclass**: Typed Python class with `from_dict()`, `to_dict()`, `is_custom_type()` methods
+- **Validation Pipeline Integration**: Artifact declarations validated as part of `ContractValidator.validate_contract()` flow
+- **Accessor API**: `BundledStandardWrapper.get_artifact_declaration()` and `get_artifact_declarations()` methods
+- **Comprehensive Test Suite**: 53 new tests across 5 test classes covering dataclass, validation, integration, and accessor API
+- **Example Contracts**: `artifact_declaration_example.yaml` and `multi_artifact_example.yaml` in ADRI/contracts/
+
+### Technical Details
+- New module: `src/adri/contracts/artifact.py` — constants, dataclass, and validation functions
+- Updated: `schema.py` (OPTIONAL_SECTIONS), `validator.py` (pipeline wiring), `engine.py` (accessor methods)
+- Exports: `ArtifactDeclaration` available via `from adri import ArtifactDeclaration` and `from adri.contracts import ArtifactDeclaration`
+- Warning (not error) for `lifecycle: persistent` without `retention_days` — per community feedback
+
+### Package Information
+- PyPI: `verodat-adri` v7.3.0 (enterprise), `adri` v7.3.0 (open source)
+- Requires: Python 3.10+
+- Tests: All passing (53 new + existing suite)
+
+---
+
+---
+
 ## [7.2.0] - 2026-01-19
 
 **verodat-adri v7.2.0 - Code Quality and Documentation Accuracy Release**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -937,4 +937,62 @@ print(f"Total amount: ${total_amount:,.2f}")
 
 ---
 
+---
+
+## Artifact Declaration API (v7.3.0)
+
+### ArtifactDeclaration Dataclass
+
+```python
+from adri import ArtifactDeclaration
+# or: from adri.contracts import ArtifactDeclaration
+
+decl = ArtifactDeclaration(
+    type="report",
+    render_hints={"format": "markdown"},
+    channel_compatibility=["cli", "slack"],
+    lifecycle="ephemeral",       # default
+    retention_days=None,         # optional, for persistent lifecycle
+)
+
+# Factory method from dict (e.g., from YAML)
+decl = ArtifactDeclaration.from_dict({"type": "report", "render_hints": {"format": "json"}})
+
+# Serialize back to dict
+d = decl.to_dict()
+
+# Check for custom type
+decl.is_custom_type()  # True if type starts with "x-custom-"
+```
+
+### Accessor Methods on BundledStandardWrapper
+
+```python
+from adri.validator.engine import BundledStandardWrapper
+
+wrapper = BundledStandardWrapper(contract_dict)
+
+# Get single declaration (first one, or None)
+decl = wrapper.get_artifact_declaration()
+if decl:
+    print(decl.type, decl.render_hints["format"])
+
+# Get all declarations as list
+declarations = wrapper.get_artifact_declarations()
+for d in declarations:
+    print(d.type, d.lifecycle)
+```
+
+### Constants
+
+```python
+from adri.contracts import (
+    VALID_ARTIFACT_TYPES,    # {"report", "ui_component", "dataset_push", ...}
+    VALID_RENDER_FORMATS,    # {"markdown", "json", "html", "a2ui_json", "text"}
+    VALID_LIFECYCLES,        # {"ephemeral", "persistent"}
+    CUSTOM_TYPE_PREFIX,      # "x-custom-"
+    DEFAULT_LIFECYCLE,       # "ephemeral"
+)
+```
+
 **Questions?** See [FAQ.md](FAQ.md) or open an issue on GitHub.

--- a/docs/DATA_CONTRACTS.md
+++ b/docs/DATA_CONTRACTS.md
@@ -33,7 +33,7 @@ field_requirements:
         severity: CRITICAL
         rule_expression: IS_NOT_NULL
       - name: customer_id must be unique
-        severity: CRITICAL  
+        severity: CRITICAL
         rule_expression: IS_UNIQUE
 ```
 
@@ -80,7 +80,7 @@ When ADRI validates data against a contract:
 **Step 3: SLA Compliance**
 ```
 ✓ Overall score ≥ min_score
-✓ Dimension scores meet requirements  
+✓ Dimension scores meet requirements
 ✓ Row readiness threshold met
 ```
 
@@ -115,12 +115,12 @@ ADRI contracts enable **domain-owned data products**:
 standards:
   name: Customer Service Data Contract
   authority: Customer Success Team
-  
+
 requirements:
   overall_minimum: 90.0  # SLA
-  
+
 field_requirements:
-  customer_id: 
+  customer_id:
     nullable: false      # Schema contract
     validation_rules:    # Quality contract
       - severity: CRITICAL
@@ -168,7 +168,7 @@ Business entity contracts (customers, orders, transactions):
 Integration contracts for AI frameworks:
 
 ```yaml
-# ADRI/contracts/frameworks/langchain_chain_input_standard.yaml  
+# ADRI/contracts/frameworks/langchain_chain_input_standard.yaml
 # Contract for: LangChain chain inputs
 # Owner: AI Team
 # Consumers: LangChain-based agents
@@ -247,7 +247,7 @@ Track contract evolution:
 ```yaml
 standards:
   version: 2.1.0
-  
+
 metadata:
   last_updated: 2025-01-15
   update_notes: "Added email validation rule to contract"
@@ -322,13 +322,13 @@ field_requirements:
     validation_rules:
       - severity: CRITICAL
         rule_expression: IS_UNIQUE
-        
+
   email:
     pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
     validation_rules:
       - severity: CRITICAL
         rule_expression: REGEX_MATCH('...')
-        
+
   status:
     valid_values: [ACTIVE, INACTIVE]
 
@@ -375,3 +375,58 @@ def update_patient_record(patient_data):
 - Contract violations prevent bad data from reaching agents
 
 This positions ADRI as the **contract enforcement layer** in modern data architectures, bridging data mesh principles with AI agent reliability.
+
+---
+
+## Artifact Declaration (v7.3.0)
+
+ADRI contracts can now include an optional **artifact declaration** section that declares what the validated output IS FOR — is it a report, a UI component, a dataset push, a notification? This enables automatic routing of validated data to rendering surfaces.
+
+### Artifact Declaration Section
+
+Two forms are supported (mutually exclusive):
+
+```yaml
+# Singular form (single artifact)
+artifact_declaration:
+  type: report
+  render_hints:
+    format: markdown
+  lifecycle: ephemeral
+
+# Plural form (multiple artifacts)
+artifact_declarations:
+  - type: report
+    render_hints:
+      format: markdown
+  - type: ui_component
+    render_hints:
+      format: a2ui_json
+    lifecycle: persistent
+    retention_days: 90
+```
+
+### Core Artifact Types
+
+| Type | Description |
+|------|-------------|
+| `report` | Analysis or summary document |
+| `ui_component` | Interactive UI element (A2UI-compatible) |
+| `dataset_push` | Data to be written to external store |
+| `notification` | Alert or status update |
+| `config_update` | Configuration change |
+| `scaffold` | Generated code/template artifact |
+| `certification_evidence` | Certification run results |
+
+Custom types use the `x-custom-*` prefix (e.g., `x-custom-verodat-sync`).
+
+### Render Formats
+
+`render_hints.format` is required and must be one of: `markdown`, `json`, `html`, `a2ui_json`, `text`.
+
+### Lifecycle
+
+- `ephemeral` (default) — run-scoped, does not outlive the assessment run
+- `persistent` — outlives the run, optionally with `retention_days`
+
+See `ADRI/contracts/artifact_declaration_example.yaml` and `ADRI/contracts/multi_artifact_example.yaml` for complete examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,4 +250,4 @@ precision = 2
 version_scheme = "post-release"
 local_scheme = "node-and-date"
 write_to = "src/adri/_version.py"
-fallback_version = "7.1.0"
+fallback_version = "7.3.0"

--- a/src/adri/__init__.py
+++ b/src/adri/__init__.py
@@ -43,6 +43,7 @@ Learn more: https://github.com/adri-standard/adri
 
 from .analysis import ContractGenerator, DataProfiler, TypeInference
 from .config.loader import ConfigurationLoader
+from .contracts.artifact import ArtifactDeclaration
 
 # Core public API imports
 from .decorator import adri_protected
@@ -68,6 +69,7 @@ __all__ = [
     "DataProfiler",
     "ContractGenerator",
     "TypeInference",
+    "ArtifactDeclaration",
 ]
 
 # Package metadata

--- a/src/adri/analysis/data_profiler.py
+++ b/src/adri/analysis/data_profiler.py
@@ -195,7 +195,7 @@ class DataProfiler:
             ProfileResult containing comprehensive data profile
         """
         if data is None:
-            from src.adri.core.exceptions import DataValidationError
+            from ..core.exceptions import DataValidationError
 
             raise DataValidationError("Data cannot be None")
 

--- a/src/adri/contracts/__init__.py
+++ b/src/adri/contracts/__init__.py
@@ -1,1 +1,23 @@
 """ADRI standards package."""
+
+from .artifact import (
+    ARTIFACT_DECLARATION_KEY,
+    ARTIFACT_DECLARATIONS_KEY,
+    ArtifactDeclaration,
+    CUSTOM_TYPE_PREFIX,
+    DEFAULT_LIFECYCLE,
+    VALID_ARTIFACT_TYPES,
+    VALID_LIFECYCLES,
+    VALID_RENDER_FORMATS,
+)
+
+__all__ = [
+    "ArtifactDeclaration",
+    "VALID_ARTIFACT_TYPES",
+    "VALID_RENDER_FORMATS",
+    "VALID_LIFECYCLES",
+    "CUSTOM_TYPE_PREFIX",
+    "DEFAULT_LIFECYCLE",
+    "ARTIFACT_DECLARATION_KEY",
+    "ARTIFACT_DECLARATIONS_KEY",
+]

--- a/src/adri/contracts/artifact.py
+++ b/src/adri/contracts/artifact.py
@@ -1,0 +1,393 @@
+"""
+Artifact declaration types and validation for ADRI contracts.
+
+This module defines the ArtifactDeclaration dataclass and validation functions
+for the optional artifact_declaration / artifact_declarations section in ADRI
+contracts. This enables protocol compatibility with A2UI, MCP, WebMCP, and A2A
+by declaring what validated data outputs are FOR — reports, UI components,
+dataset pushes, notifications, etc.
+
+See RFC Discussion #100 and Feature Issue #101 on adri-standard/adri.
+
+New in v7.3.0.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Core artifact types (7 types)
+VALID_ARTIFACT_TYPES: set[str] = {
+    "report",  # Analysis or summary document
+    "ui_component",  # Interactive UI element (A2UI-compatible)
+    "dataset_push",  # Data to be written to external store
+    "notification",  # Alert or status update
+    "config_update",  # Configuration change
+    "scaffold",  # Generated code/template artifact
+    "certification_evidence",  # Certification run results with convergence data
+}
+
+# Extension prefix for platform-specific custom types
+CUSTOM_TYPE_PREFIX: str = "x-custom-"
+
+# Valid render hint formats
+VALID_RENDER_FORMATS: set[str] = {"markdown", "json", "html", "a2ui_json", "text"}
+
+# Valid lifecycle values
+VALID_LIFECYCLES: set[str] = {"ephemeral", "persistent"}
+
+# Default lifecycle value
+DEFAULT_LIFECYCLE: str = "ephemeral"
+
+# Section key names used in contracts
+ARTIFACT_DECLARATION_KEY: str = "artifact_declaration"
+ARTIFACT_DECLARATIONS_KEY: str = "artifact_declarations"
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ArtifactDeclaration:
+    """
+    Represents a single artifact declaration in an ADRI contract.
+
+    Declares what kind of actionable artifact the validated output represents
+    and how it should be rendered/consumed by downstream platforms.
+
+    Attributes:
+        type: Artifact type — one of 7 core types or x-custom-* extension.
+        render_hints: Dictionary of rendering hints (format required, others optional).
+        channel_compatibility: Optional list of compatible rendering channels.
+        lifecycle: "ephemeral" (run-scoped, default) or "persistent" (outlives run).
+        retention_days: Optional retention period for persistent artifacts.
+    """
+
+    type: str
+    render_hints: dict[str, Any] = field(default_factory=dict)
+    channel_compatibility: list[str] | None = None
+    lifecycle: str = DEFAULT_LIFECYCLE
+    retention_days: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary representation."""
+        result: dict[str, Any] = {
+            "type": self.type,
+            "render_hints": self.render_hints,
+            "lifecycle": self.lifecycle,
+        }
+        if self.channel_compatibility is not None:
+            result["channel_compatibility"] = self.channel_compatibility
+        if self.retention_days is not None:
+            result["retention_days"] = self.retention_days
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ArtifactDeclaration":
+        """Create ArtifactDeclaration from a dictionary."""
+        return cls(
+            type=data.get("type", ""),
+            render_hints=data.get("render_hints", {}),
+            channel_compatibility=data.get("channel_compatibility"),
+            lifecycle=data.get("lifecycle", DEFAULT_LIFECYCLE),
+            retention_days=data.get("retention_days"),
+        )
+
+    def is_custom_type(self) -> bool:
+        """Check if this artifact uses a custom (x-custom-*) type."""
+        return self.type.startswith(CUSTOM_TYPE_PREFIX)
+
+
+# ---------------------------------------------------------------------------
+# Validation functions
+# ---------------------------------------------------------------------------
+
+
+def validate_artifact_type(artifact_type: str, field_path: str) -> list[str]:
+    """
+    Validate an artifact type value.
+
+    Accepts:
+    - Any of the 7 core types in VALID_ARTIFACT_TYPES
+    - Any string starting with CUSTOM_TYPE_PREFIX ("x-custom-")
+
+    Args:
+        artifact_type: The type value to validate.
+        field_path: Dot-notation path for error messages.
+
+    Returns:
+        List of error messages (empty if valid).
+    """
+    errors: list[str] = []
+
+    if not isinstance(artifact_type, str):
+        errors.append(
+            f"{field_path}.type must be a string, "
+            f"got {type(artifact_type).__name__}"
+        )
+        return errors
+
+    if not artifact_type:
+        errors.append(f"{field_path}.type is required and must not be empty")
+        return errors
+
+    if artifact_type not in VALID_ARTIFACT_TYPES and not artifact_type.startswith(
+        CUSTOM_TYPE_PREFIX
+    ):
+        valid_list = ", ".join(sorted(VALID_ARTIFACT_TYPES))
+        errors.append(
+            f"{field_path}.type '{artifact_type}' is not a valid artifact type. "
+            f"Must be one of: {valid_list}, or start with '{CUSTOM_TYPE_PREFIX}'"
+        )
+
+    return errors
+
+
+def validate_render_hints(render_hints: Any, field_path: str) -> list[str]:
+    """
+    Validate render_hints structure.
+
+    The render_hints dict MUST contain a 'format' key with a value from
+    VALID_RENDER_FORMATS. Other keys are allowed (platform-specific hints)
+    and are not strictly validated.
+
+    Args:
+        render_hints: The render_hints value to validate.
+        field_path: Dot-notation path for error messages.
+
+    Returns:
+        List of error messages (empty if valid).
+    """
+    errors: list[str] = []
+    hints_path = f"{field_path}.render_hints"
+
+    if not isinstance(render_hints, dict):
+        errors.append(
+            f"{hints_path} must be a dictionary, " f"got {type(render_hints).__name__}"
+        )
+        return errors
+
+    if "format" not in render_hints:
+        errors.append(
+            f"{hints_path}.format is required. "
+            f"Must be one of: {', '.join(sorted(VALID_RENDER_FORMATS))}"
+        )
+        return errors
+
+    fmt = render_hints["format"]
+    if not isinstance(fmt, str):
+        errors.append(
+            f"{hints_path}.format must be a string, " f"got {type(fmt).__name__}"
+        )
+    elif fmt not in VALID_RENDER_FORMATS:
+        errors.append(
+            f"{hints_path}.format '{fmt}' is not valid. "
+            f"Must be one of: {', '.join(sorted(VALID_RENDER_FORMATS))}"
+        )
+
+    return errors
+
+
+def validate_lifecycle(
+    lifecycle: Any, field_path: str, has_retention_days: bool
+) -> tuple[list[str], list[str]]:
+    """
+    Validate lifecycle value and retention_days consistency.
+
+    Args:
+        lifecycle: The lifecycle value to validate.
+        field_path: Dot-notation path for error messages.
+        has_retention_days: Whether retention_days is present in the declaration.
+
+    Returns:
+        Tuple of (errors, warnings). Warnings are non-fatal issues.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if lifecycle is None:
+        # lifecycle is optional; defaults to "ephemeral"
+        return errors, warnings
+
+    if not isinstance(lifecycle, str):
+        errors.append(
+            f"{field_path}.lifecycle must be a string, "
+            f"got {type(lifecycle).__name__}"
+        )
+        return errors, warnings
+
+    if lifecycle not in VALID_LIFECYCLES:
+        errors.append(
+            f"{field_path}.lifecycle '{lifecycle}' is not valid. "
+            f"Must be one of: {', '.join(sorted(VALID_LIFECYCLES))}"
+        )
+        return errors, warnings
+
+    # Warn if persistent without retention_days (non-fatal)
+    if lifecycle == "persistent" and not has_retention_days:
+        warnings.append(
+            f"{field_path}.lifecycle is 'persistent' but no retention_days specified. "
+            "Consider adding retention_days for data governance."
+        )
+
+    return errors, warnings
+
+
+def validate_single_artifact_declaration(
+    declaration: Any, field_path: str
+) -> tuple[list[str], list[str]]:
+    """
+    Validate a single artifact declaration dictionary.
+
+    Args:
+        declaration: The artifact declaration dict to validate.
+        field_path: Dot-notation path for error messages.
+
+    Returns:
+        Tuple of (errors, warnings).
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not isinstance(declaration, dict):
+        errors.append(
+            f"{field_path} must be a dictionary, " f"got {type(declaration).__name__}"
+        )
+        return errors, warnings
+
+    # Validate type (required)
+    if "type" not in declaration:
+        errors.append(f"{field_path}.type is required")
+    else:
+        type_errors = validate_artifact_type(declaration["type"], field_path)
+        errors.extend(type_errors)
+
+    # Validate render_hints (required)
+    if "render_hints" not in declaration:
+        errors.append(
+            f"{field_path}.render_hints is required and must contain a 'format' key"
+        )
+    else:
+        hints_errors = validate_render_hints(declaration["render_hints"], field_path)
+        errors.extend(hints_errors)
+
+    # Validate lifecycle (optional)
+    has_retention_days = "retention_days" in declaration
+    lifecycle_val = declaration.get("lifecycle")
+    if lifecycle_val is not None:
+        lifecycle_errors, lifecycle_warnings = validate_lifecycle(
+            lifecycle_val, field_path, has_retention_days
+        )
+        errors.extend(lifecycle_errors)
+        warnings.extend(lifecycle_warnings)
+    elif has_retention_days:
+        # retention_days present without explicit lifecycle
+        warnings.append(
+            f"{field_path} has retention_days but lifecycle defaults to 'ephemeral'. "
+            "Set lifecycle to 'persistent' if retention is intended."
+        )
+
+    # Validate retention_days type if present
+    if has_retention_days:
+        retention = declaration["retention_days"]
+        if not isinstance(retention, int) or isinstance(retention, bool):
+            errors.append(
+                f"{field_path}.retention_days must be a positive integer, "
+                f"got {type(retention).__name__}"
+            )
+        elif retention <= 0:
+            errors.append(
+                f"{field_path}.retention_days must be a positive integer, got {retention}"
+            )
+
+    # Validate channel_compatibility type if present
+    if "channel_compatibility" in declaration:
+        channels = declaration["channel_compatibility"]
+        if not isinstance(channels, list):
+            errors.append(
+                f"{field_path}.channel_compatibility must be a list, "
+                f"got {type(channels).__name__}"
+            )
+        elif not all(isinstance(c, str) for c in channels):
+            errors.append(
+                f"{field_path}.channel_compatibility must contain only strings"
+            )
+
+    return errors, warnings
+
+
+def validate_artifact_declaration_section(
+    contract: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """
+    Validate the artifact_declaration / artifact_declarations section of a contract.
+
+    Supports both forms:
+    - artifact_declaration (singular, dict) — treated as single-element array
+    - artifact_declarations (plural, list of dicts) — array of declarations
+
+    The two forms are mutually exclusive.
+
+    Args:
+        contract: The full contract dictionary.
+
+    Returns:
+        Tuple of (errors, warnings).
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    has_singular = ARTIFACT_DECLARATION_KEY in contract
+    has_plural = ARTIFACT_DECLARATIONS_KEY in contract
+
+    # Neither present — valid (section is optional)
+    if not has_singular and not has_plural:
+        return errors, warnings
+
+    # Mutually exclusive check
+    if has_singular and has_plural:
+        errors.append(
+            "Contract must not contain both 'artifact_declaration' (singular) and "
+            "'artifact_declarations' (plural). Use one form only."
+        )
+        return errors, warnings
+
+    # Singular form: must be a dict
+    if has_singular:
+        declaration = contract[ARTIFACT_DECLARATION_KEY]
+        decl_errors, decl_warnings = validate_single_artifact_declaration(
+            declaration, "artifact_declaration"
+        )
+        errors.extend(decl_errors)
+        warnings.extend(decl_warnings)
+        return errors, warnings
+
+    # Plural form: must be a list of dicts
+    declarations = contract[ARTIFACT_DECLARATIONS_KEY]
+    if not isinstance(declarations, list):
+        errors.append(
+            f"artifact_declarations must be a list, "
+            f"got {type(declarations).__name__}"
+        )
+        return errors, warnings
+
+    if len(declarations) == 0:
+        errors.append(
+            "artifact_declarations must not be empty. "
+            "Provide at least one artifact declaration or remove the section."
+        )
+        return errors, warnings
+
+    for idx, decl in enumerate(declarations):
+        decl_errors, decl_warnings = validate_single_artifact_declaration(
+            decl, f"artifact_declarations[{idx}]"
+        )
+        errors.extend(decl_errors)
+        warnings.extend(decl_warnings)
+
+    return errors, warnings

--- a/src/adri/contracts/schema.py
+++ b/src/adri/contracts/schema.py
@@ -6,9 +6,9 @@ for ADRI standard files, providing the foundation for comprehensive validation.
 """
 
 from dataclasses import dataclass
-from typing import Any, List, Dict, Union
+from typing import Any
 
-from .derivation import validate_enhanced_allowed_values, get_category_values
+from .derivation import get_category_values, validate_enhanced_allowed_values
 
 
 @dataclass
@@ -45,7 +45,13 @@ class StandardSchema:
 
     # Top-level sections
     REQUIRED_SECTIONS = ["contracts", "requirements"]
-    OPTIONAL_SECTIONS: list[str] = ["record_identification", "metadata", "dimensions"]
+    OPTIONAL_SECTIONS: list[str] = [
+        "record_identification",
+        "metadata",
+        "dimensions",
+        "artifact_declaration",
+        "artifact_declarations",
+    ]
 
     # Contracts section required fields
     CONTRACTS_REQUIRED_FIELDS = ["id", "name", "version", "description"]
@@ -602,8 +608,8 @@ class StandardSchema:
 
     @classmethod
     def get_allowed_values_as_list(
-        cls, allowed_values: Union[List[str], Dict[str, Any]]
-    ) -> List[str]:
+        cls, allowed_values: list[str] | dict[str, Any]
+    ) -> list[str]:
         """
         Extract valid category values from either simple or enhanced format.
 

--- a/src/adri/contracts/validator.py
+++ b/src/adri/contracts/validator.py
@@ -9,6 +9,7 @@ import os
 import threading
 from typing import Any
 
+from .artifact import validate_artifact_declaration_section
 from .exceptions import ValidationResult
 from .schema import StandardSchema
 
@@ -67,6 +68,7 @@ class ContractValidator:
         if result.is_valid:
             self._validate_contracts_section(contract, result)
             self._validate_requirements_section(contract, result)
+            self._validate_artifact_declarations(contract, result)
 
         # Cache result if path provided
         if contract_path:
@@ -448,6 +450,34 @@ class ContractValidator:
                     )
             # Otherwise, validate as old format (backward compatible)
             # Old format is valid, just different structure - no validation needed
+
+    def _validate_artifact_declarations(
+        self, contract: dict[str, Any], result: ValidationResult
+    ) -> None:
+        """
+        Validate optional artifact_declaration / artifact_declarations section.
+
+        Delegates to the artifact module's validate_artifact_declaration_section()
+        which handles both singular and plural forms, mutual exclusion, and
+        per-declaration validation of type, render_hints, lifecycle, etc.
+
+        Args:
+            contract: Contract dictionary
+            result: ValidationResult to populate with errors/warnings
+        """
+        errors, warnings = validate_artifact_declaration_section(contract)
+
+        for error_msg in errors:
+            result.add_error(
+                message=error_msg,
+                path="artifact_declaration",
+                suggestion="Check artifact_declaration structure: "
+                "type (required), render_hints.format (required), "
+                "lifecycle (optional), retention_days (optional)",
+            )
+
+        for warning_msg in warnings:
+            result.add_warning(message=warning_msg, path="artifact_declaration")
 
     def _get_cached_result(self, file_path: str) -> ValidationResult | None:
         """

--- a/src/adri/validator/dimensions/completeness.py
+++ b/src/adri/validator/dimensions/completeness.py
@@ -275,8 +275,7 @@ class CompletenessAssessor(DimensionAssessor):
         """
         from collections import defaultdict
 
-        from src.adri.core.validation_rule import ValidationRule
-
+        from ...core.validation_rule import ValidationRule
         from ..rules import execute_validation_rule
 
         failures = []
@@ -380,9 +379,8 @@ class CompletenessAssessor(DimensionAssessor):
         Returns:
             Completeness score (0.0 to 20.0)
         """
-        from src.adri.core.severity import Severity
-        from src.adri.core.validation_rule import ValidationRule
-
+        from ...core.severity import Severity
+        from ...core.validation_rule import ValidationRule
         from ..rules import execute_validation_rule
 
         total_critical_checks = 0

--- a/src/adri/validator/dimensions/consistency.py
+++ b/src/adri/validator/dimensions/consistency.py
@@ -724,8 +724,7 @@ class ConsistencyAssessor(DimensionAssessor):
         """
         from collections import defaultdict
 
-        from src.adri.core.validation_rule import ValidationRule
-
+        from ...core.validation_rule import ValidationRule
         from ..rules import execute_validation_rule
 
         failures = []
@@ -829,9 +828,8 @@ class ConsistencyAssessor(DimensionAssessor):
         Returns:
             Consistency score (0.0 to 20.0)
         """
-        from src.adri.core.severity import Severity
-        from src.adri.core.validation_rule import ValidationRule
-
+        from ...core.severity import Severity
+        from ...core.validation_rule import ValidationRule
         from ..rules import execute_validation_rule
 
         total_critical_checks = 0

--- a/src/adri/validator/dimensions/freshness.py
+++ b/src/adri/validator/dimensions/freshness.py
@@ -320,8 +320,8 @@ class FreshnessAssessor(DimensionAssessor):
         Returns:
             Freshness score (0.0 to 20.0)
         """
-        from src.adri.core.severity import Severity
-        from src.adri.core.validation_rule import ValidationRule
+        from ...core.severity import Severity
+        from ...core.validation_rule import ValidationRule
 
         # Note: Freshness rules are typically metadata-driven (recency windows)
         # Most freshness rules may be INFO severity for notifications

--- a/src/adri/validator/dimensions/plausibility.py
+++ b/src/adri/validator/dimensions/plausibility.py
@@ -353,8 +353,8 @@ class PlausibilityAssessor(DimensionAssessor):
         Returns:
             Plausibility score (0.0 to 20.0)
         """
-        from src.adri.core.severity import Severity
-        from src.adri.core.validation_rule import ValidationRule
+        from ...core.severity import Severity
+        from ...core.validation_rule import ValidationRule
 
         # Note: Plausibility rules are often statistical/informational
         # Most plausibility rules may be WARNING or INFO severity

--- a/src/adri/validator/dimensions/validity.py
+++ b/src/adri/validator/dimensions/validity.py
@@ -526,8 +526,7 @@ class ValidityAssessor(DimensionAssessor):
         Returns:
             List of failure records with details
         """
-        from src.adri.core.validation_rule import ValidationRule
-
+        from ...core.validation_rule import ValidationRule
         from ..rules import execute_validation_rule
 
         failures = []
@@ -677,9 +676,8 @@ class ValidityAssessor(DimensionAssessor):
         Returns:
             Validity score (0.0 to 20.0)
         """
-        from src.adri.core.severity import Severity
-        from src.adri.core.validation_rule import ValidationRule
-
+        from ...core.severity import Severity
+        from ...core.validation_rule import ValidationRule
         from ..rules import execute_validation_rule
 
         total_critical_checks = 0

--- a/src/adri/validator/engine.py
+++ b/src/adri/validator/engine.py
@@ -197,7 +197,7 @@ class BundledStandardWrapper:
             >>> for decl in declarations:
             ...     print(decl.type, decl.render_hints.get("format"))
         """
-        from src.adri.contracts.artifact import (
+        from ..contracts.artifact import (
             ARTIFACT_DECLARATION_KEY,
             ARTIFACT_DECLARATIONS_KEY,
             ArtifactDeclaration,
@@ -255,7 +255,7 @@ class BundledStandardWrapper:
             >>> rules = wrapper.get_validation_rules_for_field("email")
             >>> critical_rules = [r for r in rules if r.severity == Severity.CRITICAL]
         """
-        from src.adri.core.validation_rule import ValidationRule
+        from ..core.validation_rule import ValidationRule
 
         all_rules = []
         dim_reqs = self.get_dimension_requirements()
@@ -294,7 +294,7 @@ class BundledStandardWrapper:
             >>> rules_by_field = wrapper.get_all_validation_rules()
             >>> email_rules = rules_by_field.get("email", [])
         """
-        from src.adri.core.validation_rule import ValidationRule
+        from ..core.validation_rule import ValidationRule
 
         rules_by_field = {}
         dim_reqs = self.get_dimension_requirements()
@@ -341,7 +341,7 @@ class BundledStandardWrapper:
             >>> validity_rules = wrapper.filter_rules_by_dimension("validity")
             >>> completeness_rules = wrapper.filter_rules_by_dimension("completeness")
         """
-        from src.adri.core.validation_rule import ValidationRule
+        from ..core.validation_rule import ValidationRule
 
         # Get all rules if not provided
         if rules is None:
@@ -369,12 +369,12 @@ class BundledStandardWrapper:
             List of ValidationRule objects with the specified severity
 
         Example:
-            >>> from src.adri.core.severity import Severity
+            >>> from adri.core.severity import Severity
             >>> critical_rules = wrapper.filter_rules_by_severity(Severity.CRITICAL)
             >>> warning_rules = wrapper.filter_rules_by_severity("WARNING")
         """
-        from src.adri.core.severity import Severity
-        from src.adri.core.validation_rule import ValidationRule
+        from ..core.severity import Severity
+        from ..core.validation_rule import ValidationRule
 
         # Convert string to Severity enum if needed
         if isinstance(severity, str):

--- a/src/adri/validator/engine.py
+++ b/src/adri/validator/engine.py
@@ -180,6 +180,67 @@ class BundledStandardWrapper:
         rid = self.standard_dict.get("record_identification", {})
         return rid if isinstance(rid, dict) else {}
 
+    def get_artifact_declarations(self) -> list:
+        """
+        Get all artifact declarations from the contract.
+
+        Supports both singular and plural forms:
+        - artifact_declaration (dict) → returns single-element list
+        - artifact_declarations (list) → returns list as-is
+        - Neither present → returns empty list
+
+        Returns:
+            List of ArtifactDeclaration dataclass instances.
+
+        Example:
+            >>> declarations = wrapper.get_artifact_declarations()
+            >>> for decl in declarations:
+            ...     print(decl.type, decl.render_hints.get("format"))
+        """
+        from src.adri.contracts.artifact import (
+            ARTIFACT_DECLARATION_KEY,
+            ARTIFACT_DECLARATIONS_KEY,
+            ArtifactDeclaration,
+        )
+
+        # Singular form
+        if ARTIFACT_DECLARATION_KEY in self.standard_dict:
+            raw = self.standard_dict[ARTIFACT_DECLARATION_KEY]
+            if isinstance(raw, dict):
+                return [ArtifactDeclaration.from_dict(raw)]
+            return []
+
+        # Plural form
+        if ARTIFACT_DECLARATIONS_KEY in self.standard_dict:
+            raw_list = self.standard_dict[ARTIFACT_DECLARATIONS_KEY]
+            if isinstance(raw_list, list):
+                return [
+                    ArtifactDeclaration.from_dict(item)
+                    for item in raw_list
+                    if isinstance(item, dict)
+                ]
+            return []
+
+        return []
+
+    def get_artifact_declaration(self):
+        """
+        Get a single artifact declaration (convenience accessor).
+
+        Returns the first artifact declaration if present, or None.
+        For contracts with multiple declarations, use get_artifact_declarations().
+
+        Returns:
+            ArtifactDeclaration instance or None if no declarations exist.
+
+        Example:
+            >>> decl = wrapper.get_artifact_declaration()
+            >>> if decl:
+            ...     print(f"Artifact type: {decl.type}")
+        """
+        declarations = self.get_artifact_declarations()
+        return declarations[0] if declarations else None
+
     def get_validation_rules_for_field(self, field_name: str) -> list[Any]:
         """
         Get all ValidationRule objects for a specific field across all dimensions.

--- a/src/adri/validator/rules.py
+++ b/src/adri/validator/rules.py
@@ -433,7 +433,7 @@ def execute_validation_rule(value: Any, rule, field_req: dict[str, Any] = None) 
     Returns:
         True if validation passes, False otherwise
     """
-    from src.adri.core.validation_rule import ValidationRule
+    from ..core.validation_rule import ValidationRule
 
     if not isinstance(rule, ValidationRule):
         return True

--- a/tests/fixtures/contracts/contract_with_artifact_declaration.yaml
+++ b/tests/fixtures/contracts/contract_with_artifact_declaration.yaml
@@ -1,0 +1,25 @@
+# Test fixture: Contract with singular artifact_declaration
+contracts:
+  id: "test-artifact-singular"
+  name: "Test Contract with Artifact Declaration"
+  version: "1.0.0"
+  description: "Tests singular artifact_declaration section"
+
+requirements:
+  overall_minimum: 75.0
+  dimension_requirements:
+    validity:
+      weight: 3
+    completeness:
+      weight: 2
+
+artifact_declaration:
+  type: report
+  render_hints:
+    format: markdown
+    template: "summary_report"
+  channel_compatibility:
+    - cli
+    - slack
+    - web_dashboard
+  lifecycle: ephemeral

--- a/tests/fixtures/contracts/contract_with_artifact_declarations.yaml
+++ b/tests/fixtures/contracts/contract_with_artifact_declarations.yaml
@@ -1,0 +1,37 @@
+# Test fixture: Contract with plural artifact_declarations (array)
+contracts:
+  id: "test-artifact-plural"
+  name: "Test Contract with Multiple Artifact Declarations"
+  version: "1.0.0"
+  description: "Tests plural artifact_declarations section"
+
+requirements:
+  overall_minimum: 75.0
+  dimension_requirements:
+    validity:
+      weight: 3
+    completeness:
+      weight: 2
+
+artifact_declarations:
+  - type: report
+    render_hints:
+      format: markdown
+    channel_compatibility:
+      - cli
+      - slack
+    lifecycle: ephemeral
+
+  - type: ui_component
+    render_hints:
+      format: a2ui_json
+      component_type: "data_table"
+    channel_compatibility:
+      - web_dashboard
+    lifecycle: persistent
+    retention_days: 30
+
+  - type: notification
+    render_hints:
+      format: text
+    lifecycle: ephemeral

--- a/tests/fixtures/contracts/contract_with_invalid_artifact.yaml
+++ b/tests/fixtures/contracts/contract_with_invalid_artifact.yaml
@@ -1,0 +1,21 @@
+# Test fixture: Contract with invalid artifact_declaration (for error testing)
+contracts:
+  id: "test-artifact-invalid"
+  name: "Test Contract with Invalid Artifact"
+  version: "1.0.0"
+  description: "Tests invalid artifact_declaration for error handling"
+
+requirements:
+  overall_minimum: 75.0
+  dimension_requirements:
+    validity:
+      weight: 3
+    completeness:
+      weight: 2
+
+artifact_declaration:
+  type: "invalid_unknown_type"
+  render_hints:
+    format: "invalid_format"
+  lifecycle: "invalid_lifecycle"
+  retention_days: -5

--- a/tests/test_artifact_declaration.py
+++ b/tests/test_artifact_declaration.py
@@ -1,0 +1,602 @@
+"""
+Comprehensive tests for the artifact_declaration feature (v7.3.0).
+
+Covers:
+- ArtifactDeclaration dataclass (from_dict, to_dict, defaults, is_custom_type)
+- Validation functions (type, render_hints, lifecycle, single declaration, section)
+- Contract validation integration (ContractValidator with artifact sections)
+- BundledStandardWrapper accessor methods (get_artifact_declaration, get_artifact_declarations)
+
+Test cases derived from RFC #100 community feedback (VeroPlay reference consumer).
+"""
+
+import pytest
+
+from src.adri.contracts.artifact import (
+    ARTIFACT_DECLARATION_KEY,
+    ARTIFACT_DECLARATIONS_KEY,
+    CUSTOM_TYPE_PREFIX,
+    DEFAULT_LIFECYCLE,
+    VALID_ARTIFACT_TYPES,
+    VALID_LIFECYCLES,
+    VALID_RENDER_FORMATS,
+    ArtifactDeclaration,
+    validate_artifact_declaration_section,
+    validate_artifact_type,
+    validate_lifecycle,
+    validate_render_hints,
+    validate_single_artifact_declaration,
+)
+from src.adri.contracts.validator import ContractValidator
+from src.adri.validator.engine import BundledStandardWrapper
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _minimal_contract(**extra_sections):
+    """Build a minimal valid contract dict, optionally adding extra top-level sections."""
+    contract = {
+        "contracts": {
+            "id": "test-id",
+            "name": "Test",
+            "version": "1.0.0",
+            "description": "Test contract",
+        },
+        "requirements": {
+            "overall_minimum": 75.0,
+            "dimension_requirements": {
+                "validity": {"weight": 3},
+                "completeness": {"weight": 2},
+            },
+        },
+    }
+    contract.update(extra_sections)
+    return contract
+
+
+# ===========================================================================
+# TestArtifactDeclarationDataclass
+# ===========================================================================
+
+class TestArtifactDeclarationDataclass:
+    """Tests for the ArtifactDeclaration dataclass."""
+
+    def test_from_dict_minimal(self):
+        """Only type and render_hints.format — matches community test case #1."""
+        data = {"type": "report", "render_hints": {"format": "markdown"}}
+        decl = ArtifactDeclaration.from_dict(data)
+        assert decl.type == "report"
+        assert decl.render_hints == {"format": "markdown"}
+        assert decl.lifecycle == DEFAULT_LIFECYCLE
+        assert decl.retention_days is None
+        assert decl.channel_compatibility is None
+
+    def test_from_dict_full(self):
+        """All fields populated."""
+        data = {
+            "type": "ui_component",
+            "render_hints": {"format": "a2ui_json", "component": "table"},
+            "channel_compatibility": ["web_dashboard", "slack"],
+            "lifecycle": "persistent",
+            "retention_days": 90,
+        }
+        decl = ArtifactDeclaration.from_dict(data)
+        assert decl.type == "ui_component"
+        assert decl.render_hints["format"] == "a2ui_json"
+        assert decl.channel_compatibility == ["web_dashboard", "slack"]
+        assert decl.lifecycle == "persistent"
+        assert decl.retention_days == 90
+
+    def test_to_dict_roundtrip(self):
+        """from_dict → to_dict preserves data."""
+        data = {
+            "type": "dataset_push",
+            "render_hints": {"format": "json"},
+            "channel_compatibility": ["cli"],
+            "lifecycle": "persistent",
+            "retention_days": 365,
+        }
+        decl = ArtifactDeclaration.from_dict(data)
+        result = decl.to_dict()
+        assert result["type"] == "dataset_push"
+        assert result["render_hints"]["format"] == "json"
+        assert result["channel_compatibility"] == ["cli"]
+        assert result["lifecycle"] == "persistent"
+        assert result["retention_days"] == 365
+
+    def test_to_dict_omits_none_optional_fields(self):
+        """to_dict omits channel_compatibility and retention_days when None."""
+        decl = ArtifactDeclaration(type="report", render_hints={"format": "text"})
+        result = decl.to_dict()
+        assert "channel_compatibility" not in result
+        assert "retention_days" not in result
+        assert result["lifecycle"] == "ephemeral"
+
+    def test_default_lifecycle(self):
+        """Defaults to 'ephemeral'."""
+        decl = ArtifactDeclaration(type="report")
+        assert decl.lifecycle == "ephemeral"
+
+    def test_is_custom_type_true(self):
+        """True for 'x-custom-foo'."""
+        decl = ArtifactDeclaration(type="x-custom-verodat-sync")
+        assert decl.is_custom_type() is True
+
+    def test_is_custom_type_false(self):
+        """False for core types like 'report'."""
+        decl = ArtifactDeclaration(type="report")
+        assert decl.is_custom_type() is False
+
+    def test_empty_render_hints_defaults(self):
+        """Empty dict by default."""
+        decl = ArtifactDeclaration(type="report")
+        assert decl.render_hints == {}
+
+
+# ===========================================================================
+# TestArtifactDeclarationValidation
+# ===========================================================================
+
+class TestArtifactDeclarationValidation:
+    """Tests for artifact validation functions."""
+
+    # --- Type validation ---
+
+    def test_valid_all_core_types(self):
+        """All 7 core types pass validation."""
+        for core_type in VALID_ARTIFACT_TYPES:
+            errors = validate_artifact_type(core_type, "test")
+            assert errors == [], f"Type '{core_type}' should be valid"
+
+    def test_valid_custom_type(self):
+        """x-custom-* types pass validation."""
+        errors = validate_artifact_type("x-custom-my-platform", "test")
+        assert errors == []
+
+    def test_invalid_type(self):
+        """Unknown type (not core, not x-custom-*) fails."""
+        errors = validate_artifact_type("invalid_unknown", "test")
+        assert len(errors) == 1
+        assert "not a valid artifact type" in errors[0]
+
+    def test_missing_type_empty_string(self):
+        """Empty type string fails with clear error message."""
+        errors = validate_artifact_type("", "test")
+        assert len(errors) == 1
+        assert "required" in errors[0]
+
+    def test_type_not_string(self):
+        """Non-string type fails."""
+        errors = validate_artifact_type(42, "test")
+        assert len(errors) == 1
+        assert "must be a string" in errors[0]
+
+    # --- Render hints validation ---
+
+    def test_valid_render_formats(self):
+        """All 5 render formats pass."""
+        for fmt in VALID_RENDER_FORMATS:
+            errors = validate_render_hints({"format": fmt}, "test")
+            assert errors == [], f"Format '{fmt}' should be valid"
+
+    def test_missing_render_hints_format(self):
+        """Missing format inside render_hints fails."""
+        errors = validate_render_hints({}, "test")
+        assert len(errors) == 1
+        assert "format is required" in errors[0]
+
+    def test_invalid_render_format(self):
+        """Invalid format value fails."""
+        errors = validate_render_hints({"format": "xml"}, "test")
+        assert len(errors) == 1
+        assert "not valid" in errors[0]
+
+    def test_render_hints_not_dict(self):
+        """render_hints as string fails."""
+        errors = validate_render_hints("not_a_dict", "test")
+        assert len(errors) == 1
+        assert "must be a dictionary" in errors[0]
+
+    def test_render_hints_extra_keys_allowed(self):
+        """Extra platform-specific keys are allowed."""
+        errors = validate_render_hints(
+            {"format": "json", "custom_key": "custom_value"}, "test"
+        )
+        assert errors == []
+
+    # --- Lifecycle validation ---
+
+    def test_valid_lifecycles(self):
+        """Both 'ephemeral' and 'persistent' pass."""
+        for lc in VALID_LIFECYCLES:
+            errors, warnings = validate_lifecycle(lc, "test", has_retention_days=False)
+            assert errors == [], f"Lifecycle '{lc}' should be valid"
+
+    def test_invalid_lifecycle(self):
+        """Unknown lifecycle fails."""
+        errors, warnings = validate_lifecycle("unknown", "test", has_retention_days=False)
+        assert len(errors) == 1
+        assert "not valid" in errors[0]
+
+    def test_persistent_without_retention_days_warns(self):
+        """Persistent without retention_days produces warning (not error)."""
+        errors, warnings = validate_lifecycle(
+            "persistent", "test", has_retention_days=False
+        )
+        assert errors == []
+        assert len(warnings) == 1
+        assert "retention_days" in warnings[0]
+
+    def test_persistent_with_retention_days_no_warning(self):
+        """Persistent with retention_days produces no warning."""
+        errors, warnings = validate_lifecycle(
+            "persistent", "test", has_retention_days=True
+        )
+        assert errors == []
+        assert warnings == []
+
+    def test_none_lifecycle_valid(self):
+        """None lifecycle (absent) is valid — defaults applied elsewhere."""
+        errors, warnings = validate_lifecycle(None, "test", has_retention_days=False)
+        assert errors == []
+        assert warnings == []
+
+    # --- Single artifact declaration validation ---
+
+    def test_valid_minimal_declaration(self):
+        """Minimal valid declaration: type + render_hints.format."""
+        errors, warnings = validate_single_artifact_declaration(
+            {"type": "report", "render_hints": {"format": "markdown"}}, "test"
+        )
+        assert errors == []
+
+    def test_missing_type_in_declaration(self):
+        """Missing type fails."""
+        errors, warnings = validate_single_artifact_declaration(
+            {"render_hints": {"format": "json"}}, "test"
+        )
+        assert any("type is required" in e for e in errors)
+
+    def test_missing_render_hints_in_declaration(self):
+        """Missing render_hints fails."""
+        errors, warnings = validate_single_artifact_declaration(
+            {"type": "report"}, "test"
+        )
+        assert any("render_hints is required" in e for e in errors)
+
+    def test_declaration_not_dict(self):
+        """Non-dict declaration fails."""
+        errors, warnings = validate_single_artifact_declaration("not_a_dict", "test")
+        assert len(errors) == 1
+        assert "must be a dictionary" in errors[0]
+
+    def test_invalid_retention_days_negative(self):
+        """Negative retention_days fails."""
+        errors, warnings = validate_single_artifact_declaration(
+            {
+                "type": "report",
+                "render_hints": {"format": "text"},
+                "retention_days": -1,
+            },
+            "test",
+        )
+        assert any("positive integer" in e for e in errors)
+
+    def test_invalid_retention_days_type(self):
+        """Non-integer retention_days fails."""
+        errors, warnings = validate_single_artifact_declaration(
+            {
+                "type": "report",
+                "render_hints": {"format": "text"},
+                "retention_days": "thirty",
+            },
+            "test",
+        )
+        assert any("positive integer" in e for e in errors)
+
+    def test_invalid_channel_compatibility_type(self):
+        """Non-list channel_compatibility fails."""
+        errors, warnings = validate_single_artifact_declaration(
+            {
+                "type": "report",
+                "render_hints": {"format": "text"},
+                "channel_compatibility": "cli",
+            },
+            "test",
+        )
+        assert any("must be a list" in e for e in errors)
+
+    def test_retention_days_without_persistent_lifecycle_warns(self):
+        """retention_days with default ephemeral lifecycle produces warning."""
+        errors, warnings = validate_single_artifact_declaration(
+            {
+                "type": "report",
+                "render_hints": {"format": "text"},
+                "retention_days": 30,
+            },
+            "test",
+        )
+        assert errors == []
+        assert len(warnings) >= 1
+        assert any("ephemeral" in w for w in warnings)
+
+
+# ===========================================================================
+# TestArtifactDeclarationSection
+# ===========================================================================
+
+class TestArtifactDeclarationSection:
+    """Tests for validate_artifact_declaration_section (top-level orchestration)."""
+
+    def test_no_artifact_section_valid(self):
+        """Contract without artifact section is valid (optional)."""
+        contract = _minimal_contract()
+        errors, warnings = validate_artifact_declaration_section(contract)
+        assert errors == []
+        assert warnings == []
+
+    def test_singular_form_valid(self):
+        """Singular artifact_declaration dict is valid."""
+        contract = _minimal_contract(
+            artifact_declaration={
+                "type": "report",
+                "render_hints": {"format": "markdown"},
+            }
+        )
+        errors, warnings = validate_artifact_declaration_section(contract)
+        assert errors == []
+
+    def test_plural_form_valid(self):
+        """Plural artifact_declarations list is valid."""
+        contract = _minimal_contract(
+            artifact_declarations=[
+                {"type": "report", "render_hints": {"format": "markdown"}},
+                {"type": "notification", "render_hints": {"format": "text"}},
+            ]
+        )
+        errors, warnings = validate_artifact_declaration_section(contract)
+        assert errors == []
+
+    def test_both_forms_mutually_exclusive(self):
+        """Both singular and plural present is an error."""
+        contract = _minimal_contract(
+            artifact_declaration={"type": "report", "render_hints": {"format": "text"}},
+            artifact_declarations=[
+                {"type": "notification", "render_hints": {"format": "text"}}
+            ],
+        )
+        errors, warnings = validate_artifact_declaration_section(contract)
+        assert len(errors) == 1
+        assert "must not contain both" in errors[0]
+
+    def test_empty_plural_list_error(self):
+        """Empty artifact_declarations list is an error."""
+        contract = _minimal_contract(artifact_declarations=[])
+        errors, warnings = validate_artifact_declaration_section(contract)
+        assert len(errors) == 1
+        assert "must not be empty" in errors[0]
+
+    def test_plural_not_list_error(self):
+        """artifact_declarations as dict (not list) is an error."""
+        contract = _minimal_contract(
+            artifact_declarations={"type": "report", "render_hints": {"format": "text"}}
+        )
+        errors, warnings = validate_artifact_declaration_section(contract)
+        assert len(errors) == 1
+        assert "must be a list" in errors[0]
+
+    def test_multiple_errors_in_plural_list(self):
+        """Each invalid entry in plural list generates errors."""
+        contract = _minimal_contract(
+            artifact_declarations=[
+                {"type": "invalid_type", "render_hints": {"format": "text"}},
+                {"type": "report"},  # missing render_hints
+            ]
+        )
+        errors, warnings = validate_artifact_declaration_section(contract)
+        assert len(errors) >= 2
+
+
+# ===========================================================================
+# TestContractWithArtifactDeclaration
+# ===========================================================================
+
+class TestContractWithArtifactDeclaration:
+    """Integration tests: ContractValidator with artifact_declaration sections."""
+
+    def setup_method(self):
+        """Create a fresh validator for each test."""
+        self.validator = ContractValidator()
+
+    def test_valid_contract_with_artifact_declaration(self):
+        """Contract with valid artifact_declaration passes validation."""
+        contract = _minimal_contract(
+            artifact_declaration={
+                "type": "report",
+                "render_hints": {"format": "markdown"},
+            }
+        )
+        result = self.validator.validate_contract(contract, use_cache=False)
+        assert result.is_valid, f"Errors: {result.errors}"
+
+    def test_valid_contract_with_artifact_declarations(self):
+        """Contract with valid artifact_declarations passes validation."""
+        contract = _minimal_contract(
+            artifact_declarations=[
+                {"type": "report", "render_hints": {"format": "markdown"}},
+                {"type": "ui_component", "render_hints": {"format": "a2ui_json"}},
+            ]
+        )
+        result = self.validator.validate_contract(contract, use_cache=False)
+        assert result.is_valid, f"Errors: {result.errors}"
+
+    def test_contract_without_artifacts_still_valid(self):
+        """Contract without any artifact section remains valid (backward compat)."""
+        contract = _minimal_contract()
+        result = self.validator.validate_contract(contract, use_cache=False)
+        assert result.is_valid
+
+    def test_invalid_artifact_produces_errors(self):
+        """Contract with invalid artifact type produces validation errors."""
+        contract = _minimal_contract(
+            artifact_declaration={
+                "type": "invalid_unknown",
+                "render_hints": {"format": "invalid_format"},
+            }
+        )
+        result = self.validator.validate_contract(contract, use_cache=False)
+        assert not result.is_valid
+        assert len(result.errors) >= 1
+
+    def test_both_forms_produces_error(self):
+        """Contract with both singular and plural produces error."""
+        contract = _minimal_contract(
+            artifact_declaration={"type": "report", "render_hints": {"format": "text"}},
+            artifact_declarations=[
+                {"type": "notification", "render_hints": {"format": "text"}}
+            ],
+        )
+        result = self.validator.validate_contract(contract, use_cache=False)
+        assert not result.is_valid
+
+    def test_persistent_without_retention_days_warning(self):
+        """Persistent lifecycle without retention_days produces warning, not error."""
+        contract = _minimal_contract(
+            artifact_declaration={
+                "type": "report",
+                "render_hints": {"format": "text"},
+                "lifecycle": "persistent",
+            }
+        )
+        result = self.validator.validate_contract(contract, use_cache=False)
+        assert result.is_valid  # Warning, not error
+        assert len(result.warnings) >= 1
+
+    def test_custom_type_valid(self):
+        """Contract with x-custom-* artifact type passes validation."""
+        contract = _minimal_contract(
+            artifact_declaration={
+                "type": "x-custom-my-platform",
+                "render_hints": {"format": "json"},
+            }
+        )
+        result = self.validator.validate_contract(contract, use_cache=False)
+        assert result.is_valid
+
+
+# ===========================================================================
+# TestBundledStandardWrapperArtifactAccess
+# ===========================================================================
+
+class TestBundledStandardWrapperArtifactAccess:
+    """Tests for BundledStandardWrapper artifact accessor methods."""
+
+    def test_get_artifact_declaration_singular(self):
+        """get_artifact_declaration() returns first declaration from singular form."""
+        standard = _minimal_contract(
+            artifact_declaration={
+                "type": "report",
+                "render_hints": {"format": "markdown"},
+            }
+        )
+        wrapper = BundledStandardWrapper(standard)
+        decl = wrapper.get_artifact_declaration()
+        assert decl is not None
+        assert decl.type == "report"
+        assert decl.render_hints["format"] == "markdown"
+
+    def test_get_artifact_declaration_plural(self):
+        """get_artifact_declaration() returns first from plural form."""
+        standard = _minimal_contract(
+            artifact_declarations=[
+                {"type": "report", "render_hints": {"format": "markdown"}},
+                {"type": "notification", "render_hints": {"format": "text"}},
+            ]
+        )
+        wrapper = BundledStandardWrapper(standard)
+        decl = wrapper.get_artifact_declaration()
+        assert decl is not None
+        assert decl.type == "report"
+
+    def test_get_artifact_declaration_none(self):
+        """get_artifact_declaration() returns None when no artifacts present."""
+        standard = _minimal_contract()
+        wrapper = BundledStandardWrapper(standard)
+        decl = wrapper.get_artifact_declaration()
+        assert decl is None
+
+    def test_get_artifact_declarations_singular(self):
+        """get_artifact_declarations() wraps singular in list."""
+        standard = _minimal_contract(
+            artifact_declaration={
+                "type": "report",
+                "render_hints": {"format": "html"},
+                "lifecycle": "persistent",
+                "retention_days": 30,
+            }
+        )
+        wrapper = BundledStandardWrapper(standard)
+        declarations = wrapper.get_artifact_declarations()
+        assert len(declarations) == 1
+        assert declarations[0].type == "report"
+        assert declarations[0].lifecycle == "persistent"
+        assert declarations[0].retention_days == 30
+
+    def test_get_artifact_declarations_plural(self):
+        """get_artifact_declarations() returns all from plural form."""
+        standard = _minimal_contract(
+            artifact_declarations=[
+                {"type": "report", "render_hints": {"format": "markdown"}},
+                {
+                    "type": "ui_component",
+                    "render_hints": {"format": "a2ui_json"},
+                    "channel_compatibility": ["web_dashboard"],
+                },
+                {"type": "notification", "render_hints": {"format": "text"}},
+            ]
+        )
+        wrapper = BundledStandardWrapper(standard)
+        declarations = wrapper.get_artifact_declarations()
+        assert len(declarations) == 3
+        assert declarations[0].type == "report"
+        assert declarations[1].type == "ui_component"
+        assert declarations[1].channel_compatibility == ["web_dashboard"]
+        assert declarations[2].type == "notification"
+
+    def test_get_artifact_declarations_empty(self):
+        """get_artifact_declarations() returns empty list when no artifacts."""
+        standard = _minimal_contract()
+        wrapper = BundledStandardWrapper(standard)
+        declarations = wrapper.get_artifact_declarations()
+        assert declarations == []
+
+    def test_artifact_declaration_is_custom_type(self):
+        """ArtifactDeclaration.is_custom_type() works through wrapper."""
+        standard = _minimal_contract(
+            artifact_declaration={
+                "type": "x-custom-verodat-sync",
+                "render_hints": {"format": "json"},
+            }
+        )
+        wrapper = BundledStandardWrapper(standard)
+        decl = wrapper.get_artifact_declaration()
+        assert decl is not None
+        assert decl.is_custom_type() is True
+
+    def test_artifact_declarations_filters_non_dict_entries(self):
+        """get_artifact_declarations() skips non-dict entries gracefully."""
+        standard = _minimal_contract(
+            artifact_declarations=[
+                {"type": "report", "render_hints": {"format": "text"}},
+                "not_a_dict",
+                42,
+                {"type": "notification", "render_hints": {"format": "text"}},
+            ]
+        )
+        wrapper = BundledStandardWrapper(standard)
+        declarations = wrapper.get_artifact_declarations()
+        assert len(declarations) == 2
+        assert declarations[0].type == "report"
+        assert declarations[1].type == "notification"


### PR DESCRIPTION
## Summary

Implements **RFC Discussion #100** and resolves **Feature Issue #101**.

Adds optional `artifact_declaration` / `artifact_declarations` sections to ADRI contracts, enabling protocol compatibility with **A2UI, MCP, WebMCP, and A2A**. Contracts can now declare what validated data outputs are FOR — reports, UI components, dataset pushes, notifications, etc.

This is a **non-breaking, fully backward-compatible** addition.

> **Note**: This replaces the bloated PR #102. This is a clean 2-commit cherry-pick (23 files, 1,538 lines) directly onto `main` with no unrelated enterprise changes.

## What's Included

### New Module: `src/adri/contracts/artifact.py`
- **`ArtifactDeclaration` dataclass** with `from_dict()`, `to_dict()`, `is_custom_type()` methods
- **7 core artifact types**: `report`, `ui_component`, `dataset_push`, `notification`, `config_update`, `scaffold`, `certification_evidence`
- **Custom type extension**: `x-custom-*` prefix for platform-specific types
- **5 render formats**: `markdown`, `json`, `html`, `a2ui_json`, `text`
- **Lifecycle management**: `ephemeral` (default) and `persistent` (optional `retention_days`)

### Schema + Validation
- `artifact_declaration` and `artifact_declarations` added to `OPTIONAL_SECTIONS` in `schema.py`
- Validation wired into `ContractValidator.validate_contract()` pipeline

### Accessor API
- `BundledStandardWrapper.get_artifact_declaration()`
- `BundledStandardWrapper.get_artifact_declarations()`

## Tests
- **53 new tests** across 5 test classes — all passing
- **0 regressions** on existing test suite
- Test fixture contracts in `tests/fixtures/contracts/`

## Version Target
- `adri` v7.3.0 (open source)

Closes #101
Ref: #100