### PR TITLE
feat: Add agent mode to ADRIMode enum (v7.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to ADRI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.0] - 2026-03-04
+
+**Feature Release: Agent Mode — Governed AI Agent Delegation**
+
+This release adds the new `AGENT` mode to the ADRI Mode Detection System, enabling governed AI agent delegation with sandbox controls.
+
+Addresses Issue #108 on `adri-standard/adri` and Issue #45 on `Verodat/verodat-adri`.
+
+### Added
+- **Agent Mode**: New `AGENT = "agent"` member in `ADRIMode` enum for governed AI agent delegation with sandbox controls
+- **Mode Description**: Human-readable description for agent mode via `get_mode_description()`
+- **Mode Sections**: Agent mode section definitions with optional `input_requirements` and `output_requirements` via `get_mode_sections()`
+- **`ADRIMode.from_string("agent")`**: String-to-enum conversion support for the new agent mode
+
+### Package Information
+- PyPI: `adri` v7.4.0 (open source)
+- Requires: Python 3.10+
+
+---
+
 ## [7.3.0] - 2026-03-27
 
 **Feature Release: Artifact Declaration — Protocol Compatibility with A2UI, MCP, A2A**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,4 +250,4 @@ precision = 2
 version_scheme = "post-release"
 local_scheme = "node-and-date"
 write_to = "src/adri/_version.py"
-fallback_version = "7.3.0"
+fallback_version = "7.4.0"

--- a/src/adri/validator/modes.py
+++ b/src/adri/validator/modes.py
@@ -20,6 +20,7 @@ class ADRIMode(Enum):
     REASONING = "reasoning"
     CONVERSATION = "conversation"
     DETERMINISTIC = "deterministic"
+    AGENT = "agent"
     NONE = "none"
 
     @classmethod
@@ -115,6 +116,7 @@ def get_mode_description(mode: ADRIMode) -> str:
         ADRIMode.REASONING: "Reasoning mode for AI-driven analysis and decision-making",
         ADRIMode.CONVERSATION: "Conversation mode for interactive user dialogues",
         ADRIMode.DETERMINISTIC: "Deterministic mode for structured data transformations",
+        ADRIMode.AGENT: "Agent mode for governed AI agent delegation with sandbox controls",
         ADRIMode.NONE: "Generic template without mode-specific sections",
     }
     return descriptions.get(mode, "Unknown mode")
@@ -148,6 +150,10 @@ def get_mode_sections(mode: ADRIMode) -> dict[str, list[str]]:
             ],
         },
         ADRIMode.DETERMINISTIC: {
+            "required": [],
+            "optional": ["input_requirements", "output_requirements"],
+        },
+        ADRIMode.AGENT: {
             "required": [],
             "optional": ["input_requirements", "output_requirements"],
         },


### PR DESCRIPTION
## Summary

Adds the new `AGENT` mode to the `ADRIMode` enum for governed AI agent delegation with sandbox controls.

Synced from enterprise release Verodat/verodat-adri#46.

## Changes (3 files, 27 insertions)

### `src/adri/validator/modes.py`
- Added `AGENT = "agent"` to `ADRIMode` enum
- Added agent mode description to `get_mode_description()`
- Added agent mode sections to `get_mode_sections()`

### `pyproject.toml`
- Updated `fallback_version` to `7.4.0`

### `CHANGELOG.md`
- Added v7.4.0 changelog entry

## Verification
- ✅ No enterprise code present (`src/` only contains `adri/`)
- ✅ Only open source features included
- ✅ 3 files changed, 27 insertions, 1 deletion

Closes #108